### PR TITLE
Fix typos and escape # character

### DIFF
--- a/seedwing-policy-engine/docs/dogma.adoc
+++ b/seedwing-policy-engine/docs/dogma.adoc
@@ -49,7 +49,7 @@ But instead of declaring "this thing is of that type", `dogma` takes the appropr
 "Hey, that's duck typing!" you might say.
 Sure, maybe it is.
 
-But perhaps a difference it that duck typing tends to only worry if something can quack.
+But perhaps a difference is that duck typing tends to only worry if something can quack.
 It doesn't actually go further and say "...therefore it is indeed a duck".
 Duck typing just assumes something is duck-enough to be used in duckful ways.
 
@@ -434,7 +434,7 @@ use base64::Base64 as UndecodeThatIsh
 
 ==== Comments
 
-Comments start with `#` and continue to the end of the line.
+Comments start with `\#` and continue to the end of the line.
 We anticipate adding documentation comments using `##` but have not yet.
 
 === Example


### PR DESCRIPTION
This commit fixes a minor typo and also adds an escape to the # character as it is currently not being displayed properly.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>