### PR TITLE
feat: let the error types implement std::error::Error

### DIFF
--- a/seedwing-policy-engine/Cargo.toml
+++ b/seedwing-policy-engine/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0.152", features = [ "rc", "derive"] }
 serde_json = { version = "1.0.89", features = [ "float_roundtrip", "arbitrary_precision"] }
 log = "0.4.17"
 futures-util = "0.3.25"
+thiserror = "1"
 
 # functions
 sigstore = { version = "0.6.0", optional = true }

--- a/seedwing-policy-engine/src/error_printer.rs
+++ b/seedwing-policy-engine/src/error_printer.rs
@@ -39,7 +39,7 @@ impl<'c> ErrorPrinter<'c> {
                         format!("unexpected character found {}", inner.found().unwrap())
                     }
                     SimpleReason::Unclosed { span, delimiter } => {
-                        format!("unclosed delimeter {}", delimiter)
+                        format!("unclosed delimiter {}", delimiter)
                     }
                     SimpleReason::Custom(inner) => inner.clone(),
                 },

--- a/seedwing-policy-engine/src/runtime/mod.rs
+++ b/seedwing-policy-engine/src/runtime/mod.rs
@@ -30,10 +30,13 @@ use std::task::ready;
 pub mod cache;
 pub mod rationale;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum BuildError {
+    #[error("type ({2}) not found (@ {0}:{1:?})")]
     TypeNotFound(SourceLocation, SourceSpan, String),
+    #[error("failed to parse (@ {0}): {1}")]
     Parser(SourceLocation, ParserError),
+    #[error("argument mismatch (@ {0}:{1:?})")]
     ArgumentMismatch(SourceLocation, SourceSpan),
 }
 
@@ -126,11 +129,15 @@ impl EvaluationResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum RuntimeError {
+    #[error("lock")]
     Lock,
+    #[error("invalid state")]
     InvalidState,
+    #[error("no such type: {0}")]
     NoSuchType(TypeName),
+    #[error("no such type slot: {0}")]
     NoSuchTypeSlot(usize),
 }
 


### PR DESCRIPTION
This is achieved by using the thiserror crate, which was already in the dependency tree.

It helps with the integration with other crates, likes anyhow.

Also, fixed a typo.