### PR TITLE
Improve SBOMs for releases

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -70,6 +70,15 @@ jobs:
       - name: Check images created
         run: buildah images | grep '${{ env.IMAGE_NAME }}'
 
+      - name: Save image
+        run: podman save --multi-image-archive ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} > image.tar
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: container
+          path: image.tar
+          if-no-files-found: error
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v2
 

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -40,13 +40,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
 
-      - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@v1
-        with:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: "ghcr.io"
-
       - name: Install qemu dependency
         run: |
           sudo apt-get update

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -78,28 +78,3 @@ jobs:
           name: container
           path: image.tar
           if-no-files-found: error
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v2
-
-      - name: Check cosign
-        run: cosign version
-
-      - name: Push to ghcr.io
-        id: push-images
-        run: |
-          podman push \
-            "${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}" \
-            "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}" \
-            --digestfile "${RUNNER_TEMP}/push.digest"
-          echo "imageDigest=$(cat ${RUNNER_TEMP}/push.digest)" >> $GITHUB_OUTPUT
-          rm ${RUNNER_TEMP}/push.digest
-
-      - name: Sign the images with GitHub OIDC Token
-        env:
-          COSIGN_EXPERIMENTAL: true
-        run: |
-          imageDigest="${{ steps.push-images.outputs.imageDigest }}"
-          echo "Image Digest: ${imageDigest}"
-          # and then construct the full (pushed) name
-          cosign sign --yes --recursive "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@${imageDigest}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ permissions:
 
 env:
   SYFT_VERSION: "0.68.1"
+  IMAGE_NAME: seedwing-policy-server
 
 jobs:
 
@@ -185,6 +186,47 @@ jobs:
 
       - name: Display staging area
         run: ls -R staging
+
+      - name: Generate container SBOM
+        run: |
+          syft ~/download/image.tar --output cyclonedx-xml --catalogers rpm,cargo-auditable > staging/container.sbom.xml
+          syft ~/download/image.tar --output cyclonedx-json --catalogers rpm,cargo-auditable > staging/container.sbom.json
+
+      - name: Load container
+        run: |
+          podman load ~/download/image.tar
+
+      - name: Push to ghcr.io
+        id: push-images
+        env:
+          IMAGE: "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ needs.init.outputs.version }}"
+        run: |
+          podman push \
+            "${{ env.IMAGE_NAME }}:${{ needs.init.outputs.version }}" \
+            "${IMAGE}" \
+            --digestfile "${RUNNER_TEMP}/push.digest"
+          echo "imageDigest=$(cat ${RUNNER_TEMP}/push.digest)" >> $GITHUB_OUTPUT
+          rm ${RUNNER_TEMP}/push.digest
+
+      - name: Sign the images with GitHub OIDC Token
+        env:
+          COSIGN_EXPERIMENTAL: true
+        run: |
+          imageDigest="${{ steps.push-images.outputs.imageDigest }}"
+          echo "Image Digest: ${imageDigest}"
+          # and then construct the full (pushed) name
+          cosign sign --yes --recursive "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@${imageDigest}"
+
+      - name: Attach container SBOM
+        env:
+          IMAGE: "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ needs.init.outputs.version }}"
+        run: |
+          cosign attach sbom --sbom staging/container.sbom.xml --input-format xml --type cyclonedx ${IMAGE}
+          cosign sign --attachment sbom ${IMAGE}
+
+      - run: |
+          cp ~/download/image.tar staging/container.tar
+          xz staging/container.tar
 
       - name: Create Release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -127,6 +127,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install cyclonedx cli
+        run: |
+          curl -sLO https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
+          sudo install cyclonedx-linux-x64 /usr/local/bin/cyclonedx
+          cyclonedx --version
+
       - name: Install convco
         run: |
           curl -sLO https://github.com/convco/convco/releases/download/v0.3.15/convco-ubuntu.zip
@@ -189,12 +195,12 @@ jobs:
 
       - name: Generate container SBOM
         run: |
-          syft ~/download/image.tar --output cyclonedx-xml --catalogers rpm,cargo-auditable > staging/container.sbom.xml
-          syft ~/download/image.tar --output cyclonedx-json --catalogers rpm,cargo-auditable > staging/container.sbom.json
+          syft ~/download/container/image.tar --output cyclonedx-xml --catalogers rpm,cargo-auditable > staging/container.sbom.xml
+          syft ~/download/container/image.tar --output cyclonedx-json --catalogers rpm,cargo-auditable > staging/container.sbom.json
 
       - name: Load container
         run: |
-          podman load ~/download/image.tar
+          podman load --input ~/download/container/image.tar
 
       - name: Push to ghcr.io
         id: push-images
@@ -225,7 +231,7 @@ jobs:
           cosign sign --attachment sbom ${IMAGE}
 
       - run: |
-          cp ~/download/image.tar staging/container.tar
+          cp ~/download/container/image.tar staging/container.tar
           xz staging/container.tar
 
       - name: Create Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -155,6 +155,19 @@ jobs:
           chmod a+x convco
           sudo mv convco /usr/local/bin
 
+      - name: Fetch syft binary
+        run: |
+          curl -sL "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" -o syft.tar.gz
+          tar xzf syft.tar.gz
+          chmod a+x syft
+          sudo mv syft /usr/local/bin
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v2
+
+      - name: Check cosign
+        run: cosign version
+
       - name: Generate changelog
         run: |
           convco changelog -s --max-majors=1 --max-minors=1 --max-patches=1 > /tmp/changelog.md
@@ -171,31 +184,35 @@ jobs:
           mkdir -p staging
           cp -pv ~/download/*/seedwing-policy-server-* staging/
 
-      - name: Create SBOM of the project
+      - name: Create SBOM of the cargo project
+        # gather dependencies from cargo auditable build
         run: |
           cargo install cargo-cyclonedx
           cargo cyclonedx --all --format json
-          cp seedwing-policy-server/bom.json staging/project.sbom.json
+          cp seedwing-policy-server/bom.json staging/cargo.project.sbom.json
 
-      - name: Fetch syft binary
+      - name: Create SBOM of the web/yarn project
+        # gather (embedded) dependencies from the yarn build
         run: |
-          curl -sL "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" -o syft.tar.gz
-          tar xzf syft.tar.gz
-          chmod a+x syft
-          sudo mv syft /usr/local/bin
+          syft seedwing-policy-server/web/yarn.lock --output cyclonedx-json > staging/web.project.sbom.json
+
+      - name: Merge project SBOM
+        # merge both SBOMs
+        run: |
+          cyclonedx merge \
+            --input-files \
+            staging/cargo.project.sbom.json \
+            staging/web.project.sbom.json \
+            --output-file staging/project.sbom.json
 
       - name: Create SBOMs for binaries
         # this step will create SBOMs for binaries, based on the information embedded by `cargo auditable build`
+        # and amend the information with the web project SBOM
         run: |
           for i in $(ls staging/seedwing-policy-server*); do
-            syft ${i} --output cyclonedx-json > ${i}.sbom.json
+            syft ${i} --output cyclonedx-json > ${i}.sbom.cargo-auditable.json
+            cyclonedx merge --input-files ${i}.sbom.cargo-auditable.json staging/web.project.sbom.json --output-file ${i}.sbom.json
           done
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v2
-
-      - name: Check cosign
-        run: cosign version
 
       - name: Cosign blobs
         env:
@@ -205,12 +222,10 @@ jobs:
             cosign sign-blob --yes --b64=false ${i} --output-signature ${i}.cosign.sig --output-certificate ${i}.cosign.crt
           done
 
-      - name: Display staging area
-        run: ls -R staging
-
       - name: Generate container SBOM
         run: |
           syft ~/download/container/image.tar --output cyclonedx-json --catalogers rpm,cargo-auditable > staging/container.sbom.json
+          cyclonedx merge --input-files staging/container.sbom.json staging/web.project.sbom.json --output-file staging/container.sbom.json
 
       - name: Load container
         run: |
@@ -258,6 +273,9 @@ jobs:
       - run: |
           cp ~/download/container/image.tar staging/container.tar
           xz staging/container.tar
+
+      - name: Display staging area
+        run: ls -R staging
 
       - name: Create Release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,8 +174,8 @@ jobs:
       - name: Create SBOM of the project
         run: |
           cargo install cargo-cyclonedx
-          cargo cyclonedx --all --format xml
-          cp seedwing-policy-server/bom.xml staging/project.sbom.xml
+          cargo cyclonedx --all --format json
+          cp seedwing-policy-server/bom.json staging/project.sbom.json
 
       - name: Fetch syft binary
         run: |
@@ -188,7 +188,7 @@ jobs:
         # this step will create SBOMs for binaries, based on the information embedded by `cargo auditable build`
         run: |
           for i in $(ls staging/seedwing-policy-server*); do
-            syft ${i} --output cyclonedx-xml > ${i}.sbom.xml
+            syft ${i} --output cyclonedx-json > ${i}.sbom.json
           done
 
       - name: Install cosign
@@ -210,7 +210,6 @@ jobs:
 
       - name: Generate container SBOM
         run: |
-          syft ~/download/container/image.tar --output cyclonedx-xml --catalogers rpm,cargo-auditable > staging/container.sbom.xml
           syft ~/download/container/image.tar --output cyclonedx-json --catalogers rpm,cargo-auditable > staging/container.sbom.json
 
       - name: Load container

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -127,6 +127,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      # cache cargo data, not because of the build, but because of cargo based tooling
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          # although we don't use anything from the Cargo project, we still keep hashing the .lock file to get some
+          # id that aligns with the project
+          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install cyclonedx cli
         run: |
           curl -sLO https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -217,6 +217,13 @@ jobs:
         run: |
           podman load --input ~/download/container/image.tar
 
+      - name: Log in to ghcr.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: "ghcr.io"
+
       - name: Push to ghcr.io
         id: push-images
         env:
@@ -240,6 +247,7 @@ jobs:
 
       - name: Attach container SBOM information
         env:
+          COSIGN_EXPERIMENTAL: true
           IMAGE: "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ needs.init.outputs.version }}"
         run: |
           # attach and sign SBOM

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -223,12 +223,15 @@ jobs:
           # and then construct the full (pushed) name
           cosign sign --yes --recursive "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@${imageDigest}"
 
-      - name: Attach container SBOM
+      - name: Attach container SBOM information
         env:
           IMAGE: "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ needs.init.outputs.version }}"
         run: |
-          cosign attach sbom --sbom staging/container.sbom.xml --input-format xml --type cyclonedx ${IMAGE}
+          # attach and sign SBOM
+          cosign attach sbom --sbom staging/container.sbom.json --input-format json --type cyclonedx ${IMAGE}
           cosign sign --attachment sbom ${IMAGE}
+          # attach SBOM as attestation
+          cosign attest --yes --recursive  --type cyclonedx --predicate staging/container.sbom.json ${IMAGE}
 
       - run: |
           cp ~/download/container/image.tar staging/container.tar


### PR DESCRIPTION
This PR brings the following changes to the release workflow:

* Let the container workflow only build (and upload) containers, but not publish
* Publish containers as part of the "publish" step
* Generate SBOMs for containers, attach, and sign
* Use JSON SBOMs
* Amend the crated SBOMs with the content of the yarn build (which is embedded in the binary) 