### PR TITLE
Return a JSON response upon request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,16 +21,16 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c83abf9903e1f0ad9973cc4f7b9767fd5a03a583f51a5b7a339e07987cd2724"
+checksum = "0070905b2c4a98d184c4e81025253cb192aa8a73827553f38e9410801ceb35bb"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
  "ahash 0.7.6",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bitflags",
  "brotli",
  "bytes",
@@ -52,6 +52,8 @@ dependencies = [
  "rand",
  "sha1",
  "smallvec",
+ "tokio",
+ "tokio-util",
  "tracing",
  "zstd",
 ]
@@ -131,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.2.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48f7b6534e06c7bfc72ee91db7917d4af6afe23e7d223b51e68fffbb21e96b9"
+checksum = "464e0fddc668ede5f26ec1f9557a8d44eda948732f40c6b0ad79126930eb775f"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -3000,6 +3002,7 @@ dependencies = [
  "futures-util",
  "handlebars",
  "log",
+ "mime",
  "seedwing-policy-engine",
  "serde",
  "serde_json",
@@ -4028,18 +4031,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+version = "0.12.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "6.0.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "68e4a3f57d13d0ab7e478665c60f35e2a613dcd527851c2c7287ce5c787e134a"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/seedwing-policy-server/Cargo.toml
+++ b/seedwing-policy-server/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["policy"]
 [dependencies]
 seedwing-policy-engine = { path = "../seedwing-policy-engine" }
 actix-web = "4"
+mime = "0.3"
 log = "0.4.17"
 env_logger = "0.10.0"
 futures-util = "0.3.25"

--- a/seedwing-policy-server/src/main.rs
+++ b/seedwing-policy-server/src/main.rs
@@ -19,7 +19,9 @@ use seedwing_policy_engine::lang::builder::Builder as PolicyBuilder;
 use seedwing_policy_engine::runtime::sources::Directory;
 
 use crate::cli::cli;
-use crate::policy::{display_component, display_root, display_root_no_slash, evaluate};
+use crate::policy::{
+    display_component, display_root, display_root_no_slash, evaluate_html, evaluate_json,
+};
 use crate::ui::{documentation, index};
 
 include!(concat!(env!("OUT_DIR"), "/generated-docs.rs"));
@@ -106,7 +108,8 @@ async fn main() -> std::io::Result<()> {
                     .service(display_root_no_slash)
                     .service(display_root)
                     .service(display_component)
-                    .service(evaluate)
+                    .service(evaluate_json)
+                    .service(evaluate_html)
                     .service(documentation)
                     .service(playground::display)
                     .service(playground::display_root_no_slash)

--- a/seedwing-policy-server/src/policy.rs
+++ b/seedwing-policy-server/src/policy.rs
@@ -1,7 +1,8 @@
 use crate::ui::html::Htmlifier;
 use crate::ui::rationale::Rationalizer;
-use crate::ui::LAYOUT_HTML;
-use actix_web::http::header;
+use crate::ui::{json, LAYOUT_HTML};
+use actix_web::guard::{Acceptable, Any, Guard, GuardContext, Header};
+use actix_web::http::header::{self};
 use actix_web::web::{BytesMut, Payload};
 use actix_web::{get, post};
 use actix_web::{web, HttpRequest, HttpResponse};
@@ -12,7 +13,9 @@ use seedwing_policy_engine::lang::lir::EvalTrace;
 //use seedwing_policy_engine::lang::{PackagePath, TypeName};
 use crate::ui::breadcrumbs::Breadcrumbs;
 use seedwing_policy_engine::lang::lir::EvalContext;
-use seedwing_policy_engine::runtime::{Component, ModuleHandle, PackagePath, TypeName, World};
+use seedwing_policy_engine::runtime::{
+    Component, EvaluationResult, ModuleHandle, PackagePath, TypeName, World,
+};
 use seedwing_policy_engine::value::RuntimeValue;
 use serde::Serialize;
 
@@ -22,8 +25,32 @@ pub struct PolicyQuery {
     trace: Option<bool>,
 }
 
+fn wants_json(ctx: &GuardContext) -> bool {
+    Any(Acceptable::new(mime::APPLICATION_JSON))
+        .or(Header(
+            header::CONTENT_TYPE.as_str(),
+            mime::APPLICATION_JSON.essence_str(),
+        ))
+        .check(ctx)
+}
+
+#[post("/policy/{path:.*}", guard = "wants_json")]
+pub async fn evaluate_json(
+    world: web::Data<World>,
+    path: web::Path<String>,
+    input: web::Json<serde_json::Value>,
+    params: web::Query<PolicyQuery>,
+) -> HttpResponse {
+    let value = RuntimeValue::from(input.into_inner());
+    let path = path.replace('/', "::");
+    evaluate(world.get_ref(), path, value, params.into_inner(), |r| {
+        serde_json::to_string_pretty(&json::Result::new(r)).unwrap()
+    })
+    .await
+}
+
 #[post("/policy/{path:.*}")]
-pub async fn evaluate(
+pub async fn evaluate_html(
     req: HttpRequest,
     world: web::Data<World>,
     path: web::Path<String>,
@@ -42,33 +69,48 @@ pub async fn evaluate(
         let value = RuntimeValue::from(result);
         let path = path.replace('/', "::");
 
-        let mut trace = EvalTrace::Disabled;
-        if let Some(true) = params.trace {
-            trace = EvalTrace::Enabled;
-        }
-        match world.evaluate(&*path, value, EvalContext::new(trace)).await {
-            Ok(result) => {
-                let rationale = Rationalizer::new(&result);
-                let rationale = rationale.rationale();
-
-                if let Some(true) = params.opa {
-                    // OPA result format
-                    let satisfied = result.satisfied();
-                    HttpResponse::Ok().json(serde_json::json!({ "result": satisfied }))
-                } else if result.satisfied() {
-                    HttpResponse::Ok().body(rationale)
-                } else {
-                    HttpResponse::UnprocessableEntity().body(rationale)
-                }
-            }
-            Err(err) => {
-                log::error!("err {:?}", err);
-                HttpResponse::InternalServerError().finish()
-            }
-        }
+        evaluate(world.get_ref(), path, value, params.into_inner(), |r| {
+            Rationalizer::new(r).rationale()
+        })
+        .await
     } else {
         log::error!("unable to parse [{:?}]", result);
         HttpResponse::BadRequest().body(format!("Unable to parse POST'd input {}", req.path()))
+    }
+}
+
+async fn evaluate<F>(
+    world: &World,
+    path: String,
+    value: RuntimeValue,
+    params: PolicyQuery,
+    formatter: F,
+) -> HttpResponse
+where
+    F: Fn(&EvaluationResult) -> String,
+{
+    let mut trace = EvalTrace::Disabled;
+    if let Some(true) = params.trace {
+        trace = EvalTrace::Enabled;
+    }
+    match world.evaluate(&*path, value, EvalContext::new(trace)).await {
+        Ok(result) => {
+            let rationale = formatter(&result);
+
+            if let Some(true) = params.opa {
+                // OPA result format
+                let satisfied = result.satisfied();
+                HttpResponse::Ok().json(serde_json::json!({ "result": satisfied }))
+            } else if result.satisfied() {
+                HttpResponse::Ok().body(rationale)
+            } else {
+                HttpResponse::UnprocessableEntity().body(rationale)
+            }
+        }
+        Err(err) => {
+            log::error!("err {:?}", err);
+            HttpResponse::InternalServerError().finish()
+        }
     }
 }
 

--- a/seedwing-policy-server/src/ui/json.rs
+++ b/seedwing-policy-server/src/ui/json.rs
@@ -1,0 +1,83 @@
+use seedwing_policy_engine::runtime::{rationale::Rationale, EvaluationResult, TypeName};
+use serde::Serialize;
+
+#[derive(Serialize, Debug, Clone)]
+pub struct Result {
+    name: Option<TypeName>,
+    input: serde_json::Value,
+    satisfied: bool,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    reason: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    rationale: Vec<Result>,
+}
+
+impl Result {
+    pub fn new(result: &EvaluationResult) -> Self {
+        let input = match result.input() {
+            Some(input) => input.as_json(),
+            None => serde_json::Value::Null,
+        };
+
+        Self {
+            name: result.ty().name(),
+            input,
+            satisfied: result.satisfied(),
+            reason: reason(result.rationale()),
+            rationale: support(result),
+        }
+    }
+}
+
+fn reason(rationale: &Rationale) -> String {
+    match rationale {
+        Rationale::Anything => "anything is satisfied by anything".to_string(),
+        Rationale::Nothing
+        | Rationale::Const(_)
+        | Rationale::Primordial(_)
+        | Rationale::Expression(_) => "".to_string(),
+        Rationale::Object(_) => if rationale.satisfied() {
+            "because all fields were satisfied"
+        } else {
+            "because not all fields were satisfied"
+        }
+        .to_string(),
+        Rationale::List(_terms) => if rationale.satisfied() {
+            "because all members were satisfied"
+        } else {
+            "because not all members were satisfied"
+        }
+        .to_string(),
+        Rationale::Chain(_terms) => if rationale.satisfied() {
+            "because the chain was satisfied"
+        } else {
+            "because the chain was not satisfied"
+        }
+        .to_string(),
+        Rationale::NotAnObject => "not an object".to_string(),
+        Rationale::NotAList => "not a list".to_string(),
+        Rationale::MissingField(name) => format!("missing field: {name}"),
+        Rationale::InvalidArgument(name) => format!("invalid argument: {name}"),
+        Rationale::Function(_, _, _) => String::new(),
+        Rationale::Refinement(_primary, _refinement) => todo!(),
+    }
+}
+
+fn support(result: &EvaluationResult) -> Vec<Result> {
+    match result.rationale() {
+        Rationale::Object(fields) => fields.iter().map(|(_, r)| Result::new(r)).collect(),
+        Rationale::List(terms) | Rationale::Chain(terms) | Rationale::Function(_, _, terms) => {
+            terms.iter().map(Result::new).collect()
+        }
+        Rationale::Anything
+        | Rationale::Nothing
+        | Rationale::NotAnObject
+        | Rationale::NotAList
+        | Rationale::MissingField(_)
+        | Rationale::InvalidArgument(_)
+        | Rationale::Const(_)
+        | Rationale::Primordial(_)
+        | Rationale::Refinement(_, _)
+        | Rationale::Expression(_) => Vec::new(),
+    }
+}

--- a/seedwing-policy-server/src/ui/mod.rs
+++ b/seedwing-policy-server/src/ui/mod.rs
@@ -7,6 +7,7 @@ use std::str::from_utf8;
 
 pub mod breadcrumbs;
 pub mod html;
+pub mod json;
 pub mod rationale;
 
 #[get("/")]

--- a/seedwing-policy-server/src/ui/rationale.rs
+++ b/seedwing-policy-server/src/ui/rationale.rs
@@ -19,7 +19,7 @@ impl<'r> Rationalizer<'r> {
         html
     }
 
-    pub fn rationale_inner(html: &mut String, result: &EvaluationResult) {
+    fn rationale_inner(html: &mut String, result: &EvaluationResult) {
         if result.satisfied() {
             html.push_str("<div class='entry satisfied'>");
         } else {
@@ -96,7 +96,7 @@ impl<'r> Rationalizer<'r> {
         html.push_str("</div>");
     }
 
-    pub fn supported_by(html: &mut String, result: &EvaluationResult) {
+    fn supported_by(html: &mut String, result: &EvaluationResult) {
         match result.rationale() {
             Rationale::Anything => {
                 html.push_str("<div>anything is satisfied by anything</div>");
@@ -184,7 +184,7 @@ impl<'r> Rationalizer<'r> {
             Rationale::Const(_) => {}
             Rationale::Primordial(_) => {}
             Rationale::Expression(_) => {}
-            Rationale::Function(val, _rationale, supporting) => {
+            Rationale::Function(val, _rationale, _supporting) => {
                 if *val {
                     match result.raw_output() {
                         Output::None => {


### PR DESCRIPTION
Fixes #37 

We now support both the `application/x-www-form-urlencoded` and `application/json` content types. If the latter is specified for the request, a JSON response will be returned.

Here are sample outputs for both passing and failing requests:

```
[jim@fedora my-app]$ curl -i  -d @test.js http://localhost:8080/policy/proxy/context
HTTP/1.1 200 OK
content-length: 1188
date: Wed, 08 Feb 2023 17:17:55 GMT

<div><div class='entry satisfied'><div class='input'><pre>{
  "hash": "bfcffcbb8f066268ac0816b1a1e5c49c202d8bac90706fe6edd9270596afac07",
  "id": {
    "_type": "m2",
    "artifact_id": "maven-plugins",
    "group_id": "org/apache/maven/plugins"
  },
  "license": null,
  "repository_id": "m2",
  "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/32/maven-plugins-32.pom"
}</pre></div><div><div>Type <code>proxy::minimum</code> was satisfied</div></div><div class='object'><div class='reason'>because all fields were satisfied:</div><div class='field satisfied'><div class='field-name'>field <code>hash</code></div><div class='entry satisfied'><div class='input'><pre>"bfcffcbb8f066268ac0816b1a1e5c49c202d8bac90706fe6edd9270596afac07"</pre></div><div><div>Type <code>string</code> was satisfied</div></div></div></div><div class='field satisfied'><div class='field-name'>field <code>url</code></div><div class='entry satisfied'><div class='input'><pre>"https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/32/maven-plugins-32.pom"</pre></div><div><div>Type <code>string</code> was satisfied</div></div></div></div></div></div><div>

[jim@fedora my-app]$ curl -i -H "Content-Type: application/json" -d @test.js http://localhost:8080/policy/proxy/context
HTTP/1.1 200 OK
content-length: 826
date: Wed, 08 Feb 2023 17:18:15 GMT

{
  "name": "proxy::minimum",
  "input": {
    "hash": "bfcffcbb8f066268ac0816b1a1e5c49c202d8bac90706fe6edd9270596afac07",
    "id": {
      "_type": "m2",
      "artifact_id": "maven-plugins",
      "group_id": "org/apache/maven/plugins"
    },
    "license": null,
    "repository_id": "m2",
    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/32/maven-plugins-32.pom"
  },
  "satisfied": true,
  "reason": "because all fields were satisfied",
  "rationale": [
    {
      "name": "string",
      "input": "bfcffcbb8f066268ac0816b1a1e5c49c202d8bac90706fe6edd9270596afac07",
      "satisfied": true
    },
    {
      "name": "string",
      "input": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/32/maven-plugins-32.pom",
      "satisfied": true
    }
  ]
}

[jim@fedora my-app]$ curl -i -H "Content-Type: application/json" -d @test.js http://localhost:8080/policy/proxy/jim
HTTP/1.1 422 Unprocessable Entity
content-length: 2686
date: Wed, 08 Feb 2023 17:18:26 GMT

{
  "name": "lang::and",
  "input": {
    "hash": "bfcffcbb8f066268ac0816b1a1e5c49c202d8bac90706fe6edd9270596afac07",
    "id": {
      "_type": "m2",
      "artifact_id": "maven-plugins",
      "group_id": "org/apache/maven/plugins"
    },
    "license": null,
    "repository_id": "m2",
    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/32/maven-plugins-32.pom"
  },
  "satisfied": false,
  "rationale": [
    {
      "name": "proxy::minimum",
      "input": {
        "hash": "bfcffcbb8f066268ac0816b1a1e5c49c202d8bac90706fe6edd9270596afac07",
        "id": {
          "_type": "m2",
          "artifact_id": "maven-plugins",
          "group_id": "org/apache/maven/plugins"
        },
        "license": null,
        "repository_id": "m2",
        "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/32/maven-plugins-32.pom"
      },
      "satisfied": true,
      "reason": "because all fields were satisfied",
      "rationale": [
        {
          "name": "string",
          "input": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/32/maven-plugins-32.pom",
          "satisfied": true
        },
        {
          "name": "string",
          "input": "bfcffcbb8f066268ac0816b1a1e5c49c202d8bac90706fe6edd9270596afac07",
          "satisfied": true
        }
      ]
    },
    {
      "name": "proxy::signed-by-jim",
      "input": {
        "hash": "bfcffcbb8f066268ac0816b1a1e5c49c202d8bac90706fe6edd9270596afac07",
        "id": {
          "_type": "m2",
          "artifact_id": "maven-plugins",
          "group_id": "org/apache/maven/plugins"
        },
        "license": null,
        "repository_id": "m2",
        "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/32/maven-plugins-32.pom"
      },
      "satisfied": false,
      "reason": "because not all fields were satisfied",
      "rationale": [
        {
          "name": null,
          "input": "bfcffcbb8f066268ac0816b1a1e5c49c202d8bac90706fe6edd9270596afac07",
          "satisfied": false,
          "rationale": [
            {
              "name": "sigstore::sha256",
              "input": "bfcffcbb8f066268ac0816b1a1e5c49c202d8bac90706fe6edd9270596afac07",
              "satisfied": true
            },
            {
              "name": "lang::refine",
              "input": [],
              "satisfied": false,
              "rationale": [
                {
                  "name": "list::any",
                  "input": [],
                  "satisfied": false
                }
              ]
            }
          ]
        }
      ]
    }
  ]
}
```
Signed-off-by: Jim Crossley <jim@crossleys.org>