### PR TITLE
Add package source names for jsf

### DIFF
--- a/seedwing-policy-engine/src/core/jsf/mod.rs
+++ b/seedwing-policy-engine/src/core/jsf/mod.rs
@@ -3,8 +3,8 @@ use crate::runtime::PackagePath;
 
 pub fn package() -> Package {
     let mut pkg = Package::new(PackagePath::from_parts(vec!["jsf"]));
-    pkg.register_source("".into(), include_str!("algorithm.dog"));
-    pkg.register_source("".into(), include_str!("public_key.dog"));
-    pkg.register_source("".into(), include_str!("signaturecore.dog"));
+    pkg.register_source("algorithm".into(), include_str!("algorithm.dog"));
+    pkg.register_source("public-key".into(), include_str!("public_key.dog"));
+    pkg.register_source("signaturecore".into(), include_str!("signaturecore.dog"));
     pkg
 }


### PR DESCRIPTION
This commit adds names for the package sources registered for jsf.

The motivation for this is that currently the when policies are loaded it looks like jfs is loaded twice:
```console
[INFO seedwing_policy_engine::lang::hir] loading jsf 
[INFO seedwing_policy_engine::lang::hir] loading jsf
```
With the changes in the commit this will instead become:
```console
[INFO seedwing_policy_engine::lang::hir] loading jsf::algorithm 
[INFO seedwing_policy_engine::lang::hir] loading jsf::public-key
```
Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>