### PR TITLE
Add check if types already contains path

### DIFF
--- a/seedwing-policy-engine/src/lang/mir/mod.rs
+++ b/seedwing-policy-engine/src/lang/mir/mod.rs
@@ -248,12 +248,19 @@ impl World {
             log::warn!("{} is not documented", path.as_type_str());
         }
 
-        self.type_slots.push(Arc::new(
+        let runtime_type = Arc::new(
             TypeHandle::new(Some(path.clone()))
                 .with_parameters(parameters)
                 .with_documentation(documentation),
-        ));
-        self.types.insert(path, self.type_slots.len() - 1);
+        );
+
+        if let Some(handle) = self.types.get_mut(&path) {
+            // self.types already contains an entry for this path so update it.
+            self.type_slots[*handle] = runtime_type;
+        } else {
+            self.type_slots.push(runtime_type);
+            self.types.insert(path, self.type_slots.len() - 1);
+        }
     }
 
     #[allow(clippy::result_large_err)]


### PR DESCRIPTION
This commit updates `World::declare` to check if the types hashmap already contains an entry for the passed-in `path` argument.

The motivation for adding this check is that without it, it is possible for the `type_slots` vector to contain entries that are "orphaned", meaning that they are not pointed to by the `types` hashmap (the value of this hashmap is an index into the type_slots vector. For more details about this issue please see the referenced writeup below.

Refs: https://github.com/danbev/learning-crypto/blob/main/notes/seedwing/playground-evaulate-issue.md
Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>