### PR TITLE
Accept YAML input and introduce 'format' query param

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3065,10 +3065,10 @@ dependencies = [
  "futures-util",
  "handlebars",
  "log",
- "mime",
  "seedwing-policy-engine",
  "serde",
  "serde_json",
+ "serde_yaml",
  "static-files",
  "tokio",
 ]

--- a/seedwing-policy-server/Cargo.toml
+++ b/seedwing-policy-server/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["policy"]
 [dependencies]
 seedwing-policy-engine = { path = "../seedwing-policy-engine" }
 actix-web = "4"
-mime = "0.3"
 log = "0.4.17"
 env_logger = "0.10.0"
 futures-util = "0.3.25"
 serde_json = "1.0.89"
+serde_yaml = "0.9"
 clap = "4.0.29"
 handlebars = "4.3.6"
 serde = { version = "1.0.152" }

--- a/seedwing-policy-server/src/main.rs
+++ b/seedwing-policy-server/src/main.rs
@@ -24,9 +24,7 @@ use seedwing_policy_engine::runtime::sources::Directory;
 
 use crate::cli::cli;
 use crate::monitor::monitor_stream;
-use crate::policy::{
-    display_component, display_root, display_root_no_slash, evaluate_html, evaluate_json,
-};
+use crate::policy::{display_component, display_root, display_root_no_slash, evaluate};
 use crate::ui::{documentation, examples, index};
 
 include!(concat!(env!("OUT_DIR"), "/generated-docs.rs"));
@@ -122,8 +120,7 @@ async fn main() -> std::io::Result<()> {
                     .service(display_root_no_slash)
                     .service(display_root)
                     .service(display_component)
-                    .service(evaluate_json)
-                    .service(evaluate_html)
+                    .service(evaluate)
                     .service(documentation)
                     .service(examples)
                     .service(playground::display)


### PR DESCRIPTION
Fixes #64 which is arguably not broken ;)

We've moved back to a single `evaluate` handler that will accept either JSON or YAML input -- if it fails one, it tries the other -- and could be easily extended to support TOML and other formats.

By default, the response will be in the format indicated by the `Content-Type` header of the request, i.e. if you pass in JSON, you get JSON back.

If you pass in an unrecognized `Content-Type`, e.g. `application/x-www-form-urlencoded`, you'll get HTML back.

You can override this default behavior to control the format of the response by including the `format` query param in the request, valid values being `html`, `json`, or `yaml`.