### PR TITLE
Clone data_sources in World::clone

### DIFF
--- a/seedwing-policy-engine/src/lang/hir/mod.rs
+++ b/seedwing-policy-engine/src/lang/hir/mod.rs
@@ -323,6 +323,7 @@ impl Clone for World {
     fn clone(&self) -> Self {
         let mut h = World::new();
         h.packages = self.packages.clone();
+        h.data_sources = self.data_sources.clone();
         h
     }
 }


### PR DESCRIPTION
This commit add cloning of the data_sources in World::clone.

The motivation for this is what without cloning the data_sources data::from usages will not work in the playground.

For example, currently the example in the documentation which uses data::from does not work:
```
pattern people = lang::or<*data::from<"people.json">>
```