### PR TITLE
Add a SPDX license expression parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3043,6 +3043,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sigstore",
+ "spdx",
  "thiserror",
  "tokio",
  "url",
@@ -3359,6 +3360,15 @@ checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spdx"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dd48832ddda0d79ca6062064d530680e24c5ee85ba1d9fae41f102b2d9f34f"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]

--- a/seedwing-policy-engine/Cargo.toml
+++ b/seedwing-policy-engine/Cargo.toml
@@ -37,6 +37,7 @@ chrono = { version = "0.4.23", features = ["serde"] }
 reqwest = "0.11.14"
 uuid = { version = "1.3.0", features = ["v4"] }
 openvex = "0.1.0"
+spdx = "0.10.0"
 
 [features]
 default = ["sigstore"]

--- a/seedwing-policy-engine/src/core/spdx/compatible.adoc
+++ b/seedwing-policy-engine/src/core/spdx/compatible.adoc
@@ -1,0 +1,12 @@
+Verifies that the given License expression is acceptable against a list of known-good licenses.
+All the licenses identifiers must be in the SPDX format.
+
+https://spdx.github.io/spdx-spec/v2-draft/SPDX-license-list/
+
+The list of known licenses must be given as a parameter. A single good license is also accepted.
+
+Example input:
+
+```
+"MIT OR Apache-2.0"
+```

--- a/seedwing-policy-engine/src/core/spdx/compatible.adoc
+++ b/seedwing-policy-engine/src/core/spdx/compatible.adoc
@@ -5,8 +5,11 @@ https://spdx.github.io/spdx-spec/v2-draft/SPDX-license-list/
 
 The list of known licenses must be given as a parameter. A single good license is also accepted.
 
-Example input:
-
+Example:
 ```
+pattern only-copyleft = spdx::compatible<["OSL-2.0", "GPL-2.0", "CC-BY-SA-2.0"]>
+
+//The following input would fail:
+
 "MIT OR Apache-2.0"
 ```

--- a/seedwing-policy-engine/src/core/spdx/compatible.rs
+++ b/seedwing-policy-engine/src/core/spdx/compatible.rs
@@ -1,0 +1,139 @@
+use crate::core::{Function, FunctionEvaluationResult};
+use crate::lang::lir::{Bindings, EvalContext, InnerType, ValueType};
+use crate::runtime::{Output, RuntimeError, World};
+use crate::value::RuntimeValue;
+use spdx;
+use spdx::{Expression, Licensee};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc; // as spdx_parser;
+
+const DOCUMENTATION: &str = include_str!("compatible.adoc");
+
+const LICENSE_REQUIREMENT: &str = "terms";
+
+#[derive(Debug)]
+pub struct Compatible;
+
+impl Function for Compatible {
+    fn order(&self) -> u8 {
+        255
+    }
+    fn documentation(&self) -> Option<String> {
+        Some(DOCUMENTATION.into())
+    }
+
+    fn parameters(&self) -> Vec<String> {
+        vec![LICENSE_REQUIREMENT.into()]
+    }
+
+    fn call<'v>(
+        &'v self,
+        input: Arc<RuntimeValue>,
+        _ctx: &'v EvalContext,
+        bindings: &'v Bindings,
+        _world: &'v World,
+    ) -> Pin<Box<dyn Future<Output = Result<FunctionEvaluationResult, RuntimeError>> + 'v>> {
+        Box::pin(async move {
+            if let Some(value) = input.try_get_string() {
+                if let Ok(license) = spdx::Expression::parse(value.as_str()) {
+                    if let Some(val) = bindings.get(LICENSE_REQUIREMENT) {
+                        if let Some(ValueType::String(license_req)) = val.try_get_resolved_value() {
+                            if let Ok(license_id) = spdx::Licensee::parse(license_req.as_str()) {
+                                if license.evaluate(|req| license_id.satisfies(req)) {
+                                    return Ok(Output::Identity.into());
+                                }
+                            }
+                        } else if let InnerType::List(license_list) = val.inner() {
+                            let list: Vec<ValueType> = license_list
+                                .to_vec()
+                                .iter()
+                                .filter_map(|t| t.try_get_resolved_value())
+                                .collect();
+                            let definitive_list: Vec<String> = list
+                                .iter()
+                                .filter_map(|t| {
+                                    if let ValueType::String(val) = t {
+                                        Some(val.clone())
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect();
+
+                            for license_req in definitive_list {
+                                if let Ok(license_id) = spdx::Licensee::parse(license_req.as_str())
+                                {
+                                    if license.evaluate(|req| license_id.satisfies(req)) {
+                                        return Ok(Output::Identity.into());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(Output::None.into())
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::core::test::test_pattern;
+
+    use serde_json::json;
+
+    #[actix_rt::test]
+    async fn gpl() {
+        let result = test_pattern(
+            r#"
+            spdx::compatible<"GPL-2.0">
+            "#,
+            json!("GPL-2.0-only"),
+        )
+        .await;
+
+        assert!(result.satisfied())
+    }
+
+    #[actix_rt::test]
+    async fn fail() {
+        let result = test_pattern(
+            r#"
+            spdx::compatible<"MIT">
+            "#,
+            json!("Apache-2.0"),
+        )
+        .await;
+
+        assert!(!result.satisfied())
+    }
+
+    #[actix_rt::test]
+    async fn multiple() {
+        let result = test_pattern(
+            r#"
+            spdx::compatible<["MIT", "GPL-2.0"]>
+            "#,
+            json!("MIT OR Apache-2.0"),
+        )
+        .await;
+
+        assert!(result.satisfied())
+    }
+
+    #[actix_rt::test]
+    async fn multiple_fails() {
+        let result = test_pattern(
+            r#"
+            spdx::compatible<["BSD", "GPL-2.0"]>
+            "#,
+            json!("MIT OR Apache-2.0"),
+        )
+        .await;
+
+        assert!(!result.satisfied())
+    }
+}

--- a/seedwing-policy-engine/src/core/spdx/compatible.rs
+++ b/seedwing-policy-engine/src/core/spdx/compatible.rs
@@ -10,7 +10,7 @@ use std::sync::Arc; // as spdx_parser;
 
 const DOCUMENTATION: &str = include_str!("compatible.adoc");
 
-const LICENSE_REQUIREMENT: &str = "terms";
+const LICENSE_REQUIREMENT: &str = "license_id";
 
 #[derive(Debug)]
 pub struct Compatible;

--- a/seedwing-policy-engine/src/core/spdx/mod.rs
+++ b/seedwing-policy-engine/src/core/spdx/mod.rs
@@ -1,8 +1,11 @@
 use crate::package::Package;
 use crate::runtime::PackagePath;
 
+mod compatible;
+
 pub fn package() -> Package {
     let mut pkg = Package::new(PackagePath::from_parts(vec!["spdx"]));
     pkg.register_source("license".into(), include_str!("license.dog"));
+    pkg.register_function("compatible".into(), compatible::Compatible);
     pkg
 }


### PR DESCRIPTION
The idea is to provide a list of valid licenses as parameters to verify against a license expression : 


`pattern only-copyleft = spdx::compatible<["OSL-2.0", "GPL-2.0", "CC-BY-SA-2.0"]>`

with the given input: `MIT OR Apache-2.0` would fail