### PR TITLE
Add support for data sources in yaml format

### DIFF
--- a/seedwing-policy-engine/src/runtime/mod.rs
+++ b/seedwing-policy-engine/src/runtime/mod.rs
@@ -145,6 +145,8 @@ pub enum RuntimeError {
     NoSuchTypeSlot(usize),
     #[error("error parsing JSON file {0}: {1}")]
     JsonError(PathBuf, serde_json::Error),
+    #[error("error parsing YAML file {0}: {1}")]
+    YamlError(PathBuf, serde_yaml::Error),
     #[error("error reading file: {0}")]
     FileUnreadable(PathBuf),
 }


### PR DESCRIPTION
This commit add support for data sources to be in yaml format. For example:
```
pattern people = lang::or<*data::from<"people.yaml">>
```
Where `people.yaml` could look like:
```yaml
---
 - "bob"
 - "jim"
```

Fixes: https://github.com/seedwing-io/seedwing-policy/issues/81