### PR TITLE
Add error logging when target is not found

### DIFF
--- a/seedwing-policy-engine/src/data/mod.rs
+++ b/seedwing-policy-engine/src/data/mod.rs
@@ -66,6 +66,7 @@ impl DataSource for DirectoryDataSource {
                 Ok(None)
             }
         } else {
+            log::error!("{:?} not found", target);
             Ok(None)
         }
     }


### PR DESCRIPTION
This commit adds an error log when the target cannot be found.

The motivation for this is that currently it is easy to make a typo in the file name of a `data::from`, in which case the rule will fail but there is no information indicating that the file name could be incorrect.  Having this logging helps but long term we should probably Err on this situation.