### PR TITLE
feat: add ability to create test assertions in policy files

### DIFF
--- a/cli/src/command/test.rs
+++ b/cli/src/command/test.rs
@@ -11,7 +11,7 @@ use tokio::io::AsyncReadExt;
 use walkdir::{DirEntry, WalkDir};
 
 #[derive(clap::Args, Debug)]
-#[command(about = "Execute benchmarks", args_conflicts_with_subcommands = true)]
+#[command(about = "Run policy tests", args_conflicts_with_subcommands = true)]
 pub struct Test {
     #[arg(short, long = "test", value_name = "DIR")]
     pub(crate) test_directories: Vec<PathBuf>,

--- a/engine/src/core/csaf/mod.rs
+++ b/engine/src/core/csaf/mod.rs
@@ -10,7 +10,7 @@ pub fn package() -> Package {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::core::test::test_pattern;
+    use crate::core::testutil::test_pattern;
     use serde_json::json;
 
     #[tokio::test]

--- a/engine/src/core/lang/map.rs
+++ b/engine/src/core/lang/map.rs
@@ -76,7 +76,7 @@ impl Function for Map {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::test::test_pattern;
+    use crate::core::testutil::test_pattern;
     use serde_json::json;
 
     #[tokio::test]

--- a/engine/src/core/lang/not.rs
+++ b/engine/src/core/lang/not.rs
@@ -57,7 +57,7 @@ impl Function for Not {
 #[cfg(test)]
 mod test {
 
-    use crate::core::test::test_pattern;
+    use crate::core::testutil::test_pattern;
 
     use serde_json::json;
 

--- a/engine/src/core/mod.rs
+++ b/engine/src/core/mod.rs
@@ -30,6 +30,7 @@ pub mod pem;
 pub mod sigstore;
 pub mod spdx;
 pub mod string;
+pub mod test;
 pub mod timestamp;
 pub mod uri;
 pub mod x509;
@@ -160,7 +161,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod testutil {
     use crate::lang::builder::Builder;
     use crate::lang::lir::EvalContext;
     use crate::runtime::sources::Ephemeral;

--- a/engine/src/core/spdx/compatible.rs
+++ b/engine/src/core/spdx/compatible.rs
@@ -74,7 +74,7 @@ impl Function for Compatible {
 #[cfg(test)]
 mod test {
 
-    use crate::core::test::test_pattern;
+    use crate::core::testutil::test_pattern;
 
     use serde_json::json;
 

--- a/engine/src/core/test/mod.rs
+++ b/engine/src/core/test/mod.rs
@@ -1,0 +1,99 @@
+use crate::core::{Function, FunctionEvaluationResult};
+use crate::lang::lir::{Bindings, EvalContext};
+use crate::package::Package;
+use crate::runtime::PackagePath;
+use crate::runtime::{Output, RuntimeError, World};
+use crate::value::RuntimeValue;
+
+use std::future::Future;
+use std::pin::Pin;
+
+use std::sync::Arc;
+
+pub fn package() -> Package {
+    let mut pkg = Package::new(PackagePath::from_parts(vec!["test"]));
+    pkg.register_function("satisfies".into(), Satisfies);
+    pkg
+}
+
+const PATTERN: &str = "pattern";
+const INPUT: &str = "input";
+
+const DOCUMENTATION: &str = include_str!("satisfies.adoc");
+
+#[derive(Debug)]
+pub struct Satisfies;
+
+impl Function for Satisfies {
+    fn order(&self) -> u8 {
+        128
+    }
+    fn parameters(&self) -> Vec<String> {
+        vec![PATTERN.into(), INPUT.into()]
+    }
+
+    fn documentation(&self) -> Option<String> {
+        Some(DOCUMENTATION.into())
+    }
+
+    fn call<'v>(
+        &'v self,
+        _input: Arc<RuntimeValue>,
+        ctx: &'v EvalContext,
+        bindings: &'v Bindings,
+        world: &'v World,
+    ) -> Pin<Box<dyn Future<Output = Result<FunctionEvaluationResult, RuntimeError>> + 'v>> {
+        Box::pin(async move {
+            match (bindings.get(PATTERN), bindings.get(INPUT)) {
+                (Some(pattern), Some(input)) => {
+                    if let Some(value) = input.try_get_resolved_value() {
+                        let result = pattern
+                            .evaluate(Arc::new(RuntimeValue::from(&value)), ctx, bindings, world)
+                            .await?;
+
+                        if result.satisfied() {
+                            return Ok((Output::Identity, vec![result]).into());
+                        } else {
+                            Ok(Output::None.into())
+                        }
+                    } else {
+                        Ok(Output::None.into())
+                    }
+                }
+                _ => Ok(Output::None.into()),
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lang::builder::Builder as PolicyBuilder;
+    use crate::runtime::sources::Ephemeral;
+
+    #[actix_rt::test]
+    async fn satisfies_assertion() {
+        let policy = include_str!("mypolicy.dog");
+        let tests = include_str!("mypolicy_test.dog");
+
+        let policy = Ephemeral::new("mypolicy", policy);
+        let tests = Ephemeral::new("mypolicy_test", tests);
+        let mut builder = PolicyBuilder::new();
+
+        builder.build(policy.iter());
+        builder.build(tests.iter());
+
+        let world = builder.finish().await.unwrap();
+        assert!(world
+            .evaluate("mypolicy_test::test1", "", EvalContext::default())
+            .await
+            .unwrap()
+            .satisfied());
+        assert!(world
+            .evaluate("mypolicy_test::test2", "", EvalContext::default())
+            .await
+            .unwrap()
+            .satisfied());
+    }
+}

--- a/engine/src/core/test/mypolicy.dog
+++ b/engine/src/core/test/mypolicy.dog
@@ -1,0 +1,1 @@
+pattern foo = "myfoo"

--- a/engine/src/core/test/mypolicy_test.dog
+++ b/engine/src/core/test/mypolicy_test.dog
@@ -1,0 +1,2 @@
+pattern test1 = test::satisfies<mypolicy::foo, "myfoo">
+pattern test2 = !test::satisfies<mypolicy::foo, "mybar">

--- a/engine/src/core/test/satisfies.adoc
+++ b/engine/src/core/test/satisfies.adoc
@@ -1,0 +1,1 @@
+Unit test helper that evaluates if a pattern satisfies an input

--- a/engine/src/core/uri/purl.rs
+++ b/engine/src/core/uri/purl.rs
@@ -116,7 +116,7 @@ impl Purl {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::core::test::test_pattern;
+    use crate::core::testutil::test_pattern;
     use serde_json::json;
 
     #[tokio::test]

--- a/engine/src/lang/hir/mod.rs
+++ b/engine/src/lang/hir/mod.rs
@@ -360,6 +360,7 @@ impl World {
         world.add_package(crate::core::uri::package());
         world.add_package(crate::core::timestamp::package());
         world.add_package(crate::core::csaf::package());
+        world.add_package(crate::core::test::package());
 
         #[cfg(feature = "debug")]
         world.add_package(crate::core::debug::package());


### PR DESCRIPTION
As discussed in chat, this allows writing unit tests in policies. It doesn't implement the runner, but just shows in a rust unit tests what this would look like.

For a policy `mypolicy.dog`, you'd write a `mypolicy_test.dog`.

mypolicy.dog
```
pattern foo = "myfoo"
```

mypolicy_test.dog:

```
pattern test1 = test::satisfies<mypolicy::foo, "myfoo">
pattern test2 = !test::satisfies<mypolicy::foo, "mybar">
```

 When running the tests, the test runner (not implemented yet) would detect the _test suffix and try to evaluate all the patterns there with the empty string as input.

The `test` module contains patterns for the assertions. It could potentially use the data::from to read policy input from a file (i think).