### PR TITLE
fix: don't trigger trunk build when yarn.lock is missing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Install nodejs dependencies
         run: |
           cd frontend
-          npm i
+          npm ci
 
       - name: Check formatting
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,11 @@ definitely try to help you.
 In order to work with the code, you will need the following tools and components:
 
 * **Rust**: For the overall project
-* **Node.js & Yarn**: For the web bits in the server
+* **Node.js & npm**: For the web bits in the server
 * **Podman or Docker**: For building the container image
 * **Trunk**: For building the web frontend
 
-Building seedwing-policy requires `nodejs` and `yarnpkg`. You can follow installation instructions [here](https://developer.fedoraproject.org/tech/languages/nodejs/nodejs.html) or run the commands appropriate for your development environment.
+Building seedwing-policy requires `nodejs` and `npm`. You can follow installation instructions [here](https://developer.fedoraproject.org/tech/languages/nodejs/nodejs.html) or run the commands appropriate for your development environment.
 
 `trunk` can be installed by executing `cargo install trunk`. It additionally requires `wasm-bindgen` and `dart-sass`, but will automatically install those tools if they are missing. Also see: https://trunkrs.dev/#install
 
@@ -43,13 +43,13 @@ For more information on developing for the frontend, see: [seedwing-policy-front
 ### Fedora
 
 ```shell
-dnf install nodejs yarnpkg
+dnf install nodejs
 ```
 
 ### Mac OS
 
 ```shell
-brew install yarn node
+brew install node
 ```
 
 ### Trunk tooling

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -37,7 +37,7 @@ In order to work on the frontend you need to:
 
   ```shell
   cd frontend
-  yarn install
+  npm ci
   ```
 
 * Run the frontend in development mode

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "console-frontend",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "console-frontend",
+      "version": "0.0.1",
+      "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.3.0",
+        "@patternfly/patternfly": "^4.224.2"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.3.0.tgz",
+      "integrity": "sha512-qVtd5i1Cc7cdrqnTWqTObKQHjPWAiRwjUPaXObaeNPcy7+WKxJumGBx66rfSFgK6LNpIasVKkEgW8oyf0tmPLA==",
+      "hasInstallScript": true,
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@patternfly/patternfly": {
+      "version": "4.224.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.224.2.tgz",
+      "integrity": "sha512-HGNV26uyHSIECuhjPg/WGn0mXbAotcs6ODfhAOkfYjIgGylddgiwElxUe1rpEHV5mQJJ2rMn4OdeJIIpzRX61g==",
+      "license": "MIT"
+    }
+  }
+}

--- a/server/embedded-frontend/build.rs
+++ b/server/embedded-frontend/build.rs
@@ -11,17 +11,32 @@ fn main() -> std::io::Result<()> {
     println!("cargo:rerun-if-changed=../../frontend/Cargo.toml");
     println!("cargo:rerun-if-changed=../../frontend/Cargo.lock");
     println!("cargo:rerun-if-changed=../../frontend/Trunk.toml");
-    println!("cargo:rerun-if-changed=../../frontend/package.json");
-    println!("cargo:rerun-if-changed=../../frontend/yarn.lock");
+    println!("cargo:rerun-if-changed=../../frontend/package-lock.json");
     println!("cargo:rerun-if-changed=../../frontend/src");
     println!("cargo:rerun-if-changed=../../frontend/assets");
 
-    let output = Command::new("trunk")
+    let npm = Command::new("npm")
+        .args(["ci"])
+        .current_dir("../../frontend")
+        .output()
+        .expect("failed to execute frontend build");
+
+    if !npm.status.success() {
+        panic!(
+            "Failed to run 'npm':\n{}\n{}",
+            String::from_utf8_lossy(&npm.stdout),
+            String::from_utf8_lossy(&npm.stderr)
+        );
+    }
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dist = Path::new(&out_dir).join("dist");
+
+    let trunk = Command::new("trunk")
         .args([
             "build",
             "--release",
             "-d",
-            "../server/embedded-frontend/dist",
+            dist.to_str().unwrap(),
             "--public-url",
             "/",
         ])
@@ -29,19 +44,17 @@ fn main() -> std::io::Result<()> {
         .output()
         .expect("failed to execute frontend build");
 
-    if !output.status.success() {
+    if !trunk.status.success() {
         panic!(
             "Failed to run 'trunk':\n{}\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
+            String::from_utf8_lossy(&trunk.stdout),
+            String::from_utf8_lossy(&trunk.stderr)
         );
     }
 
-    let mut assets = resource_dir("dist");
+    let mut assets = resource_dir(dist);
     assets
-        .with_generated_filename(
-            Path::new(&env::var("OUT_DIR").unwrap()).join("generated-console.rs"),
-        )
+        .with_generated_filename(Path::new(&out_dir).join("generated-console.rs"))
         .with_generated_fn("generate_console_assets");
 
     assets.build()?;


### PR DESCRIPTION
Moving on from yarn in favor of `npm ci` which guarantees repeatable builds by reading the lock file to recreate node_modules/