### PR TITLE
feat: add string::contains function

### DIFF
--- a/engine/src/core/string/contains.adoc
+++ b/engine/src/core/string/contains.adoc
@@ -1,7 +1,6 @@
 Function that returns true if the string contains the specified substring.
-
 ```
-pattern contains_people = string::contains<people>
+pattern contains_people = string::contains<"people">
 ```
 
 Example input:

--- a/engine/src/core/string/contains.adoc
+++ b/engine/src/core/string/contains.adoc
@@ -1,0 +1,10 @@
+Function that returns true if the string contains the specified substring.
+
+```
+pattern contains_people = string::contains<people>
+```
+
+Example input:
+```
+"Some people like coffee."
+```

--- a/engine/src/core/string/contains.rs
+++ b/engine/src/core/string/contains.rs
@@ -1,0 +1,117 @@
+use crate::core::{Function, FunctionEvaluationResult};
+use crate::lang::lir::{Bindings, InnerPattern, ValuePattern};
+use crate::runtime::{EvalContext, Output, RuntimeError, World};
+use crate::value::RuntimeValue;
+use std::future::Future;
+use std::pin::Pin;
+
+use std::sync::Arc;
+
+const DOCUMENTATION: &str = include_str!("contains.adoc");
+const SUBSTRING: &str = "substring";
+
+#[derive(Debug)]
+pub struct Contains;
+
+impl Function for Contains {
+    fn documentation(&self) -> Option<String> {
+        Some(DOCUMENTATION.into())
+    }
+
+    fn parameters(&self) -> Vec<String> {
+        vec![SUBSTRING.into()]
+    }
+
+    fn call<'v>(
+        &'v self,
+        input: Arc<RuntimeValue>,
+        _ctx: &'v EvalContext,
+        bindings: &'v Bindings,
+        _world: &'v World,
+    ) -> Pin<Box<dyn Future<Output = Result<FunctionEvaluationResult, RuntimeError>> + 'v>> {
+        Box::pin(async move {
+            if let Some(pattern) = bindings.get(SUBSTRING) {
+                if let InnerPattern::Const(ValuePattern::String(substring)) = pattern.inner() {
+                    if let Some(string) = input.try_get_string() {
+                        return Ok(
+                            Output::Transform(Arc::new(string.contains(substring).into())).into(),
+                        );
+                    }
+                }
+            }
+            Ok(Output::Transform(Arc::new(false.into())).into())
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::lang::builder::Builder;
+    use crate::runtime::sources::Ephemeral;
+    use serde_json::json;
+
+    #[actix_rt::test]
+    async fn string_contains() {
+        let src = Ephemeral::new(
+            "test",
+            r#"
+            pattern has_str = string::contains<"people">( $(self == true) )
+        "#,
+        );
+
+        let mut builder = Builder::new();
+        let _result = builder.build(src.iter());
+        let runtime = builder.finish().await.unwrap();
+        let result = runtime
+            .evaluate(
+                "test::has_str",
+                json!("Some people like coffee."),
+                EvalContext::default(),
+            )
+            .await;
+        assert!(result.as_ref().unwrap().satisfied());
+        assert_eq!(
+            result
+                .as_ref()
+                .unwrap()
+                .output()
+                .unwrap()
+                .try_get_boolean()
+                .unwrap(),
+            true
+        );
+    }
+
+    #[actix_rt::test]
+    async fn string_contains_no_substring() {
+        let src = Ephemeral::new(
+            "test",
+            r#"
+            pattern no_substring = string::contains( $(self == false) )
+        "#,
+        );
+
+        let mut builder = Builder::new();
+        let _result = builder.build(src.iter());
+        let runtime = builder.finish().await.unwrap();
+        let result = runtime
+            .evaluate(
+                "test::no_substring",
+                json!("anything old text here..."),
+                EvalContext::default(),
+            )
+            .await;
+        assert!(result.as_ref().unwrap().satisfied());
+        assert_eq!(
+            result
+                .as_ref()
+                .unwrap()
+                .output()
+                .unwrap()
+                .try_get_boolean()
+                .unwrap(),
+            false
+        );
+    }
+}

--- a/engine/src/core/string/mod.rs
+++ b/engine/src/core/string/mod.rs
@@ -1,8 +1,10 @@
 mod concat;
+mod contains;
 mod length;
 mod regexp;
 
 use crate::core::string::concat::Concat;
+use crate::core::string::contains::Contains;
 use crate::core::string::length::Length;
 use crate::core::string::regexp::Regexp;
 
@@ -16,5 +18,6 @@ pub fn package() -> Package {
     pkg.register_function("regexp".into(), Regexp);
     pkg.register_function("prepend".into(), Concat::Prepend);
     pkg.register_function("append".into(), Concat::Append);
+    pkg.register_function("contains".into(), Contains);
     pkg
 }


### PR DESCRIPTION
This commit adds a function named `string::contains` which allows for determining if a string contains a substring.

Fixes: https://github.com/seedwing-io/seedwing-policy/issues/125