### PR TITLE
Add the concept of severities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,20 +2764,21 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "picky"
-version = "7.0.0-rc.4"
+version = "7.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c80faad111028a7dc724b220316209af32d3db6b4a3251d2b8b94277d2af5c"
+checksum = "72ac7d98dfb5e53cdea76b70df8d5e8dd7717a2d685a12f54c547e03b5afd76a"
 dependencies = [
  "base64 0.13.1",
  "digest",
  "md-5",
  "num-bigint-dig",
  "oid",
+ "p256",
+ "p384",
  "picky-asn1",
  "picky-asn1-der",
  "picky-asn1-x509",
  "rand",
- "ring",
  "rsa 0.6.1",
  "serde",
  "sha-1",
@@ -3716,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "sigstore"
 version = "0.6.0"
-source = "git+https://github.com/danbev/sigstore-rs.git?branch=verify-blob#ed9391ea61d50fbecc5a5116237f324b0dc1438a"
+source = "git+https://github.com/danbev/sigstore-rs.git?branch=verify-blob#2a1c81d0ba47615e1cb541b63130effbff7d5559"
 dependencies = [
  "async-trait",
  "base64 0.21.0",
@@ -4146,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc636dd1ee889a366af6731f1b63b60baf19528b46df5a7c2d4b3bf8b60bca2d"
+checksum = "c259b2bd13fdff3305a5a92b45befb1adb315d664612c8991be57fb6a83dc126"
 dependencies = [
  "chrono",
  "dyn-clone",

--- a/docs/modules/policies/pages/showcase/index.adoc
+++ b/docs/modules/policies/pages/showcase/index.adoc
@@ -22,3 +22,20 @@ This pattern is marked deprecated, without further information.
 == `unstable`
 
 This pattern is considered unstable/experimental.
+
+[#using_asciidoc]
+== `using_asciidoc`
+
+A pattern making use of Asciidoc
+
+Like *bold*, _italic_, or `monospace`.
+
+NOTE: Also more complex constructs should be possible.
+
+Like code blocks:
+
+[source,json]
+----
+{ "foo": {"bar": true}} <1>
+----
+<1> The usual "foo bar"

--- a/engine/src/core/base64/mod.rs
+++ b/engine/src/core/base64/mod.rs
@@ -1,5 +1,5 @@
 use crate::core::{Example, Function, FunctionEvaluationResult, FunctionInput};
-use crate::lang::{lir::Bindings, PatternMeta};
+use crate::lang::{lir::Bindings, PatternMeta, Severity};
 use crate::package::Package;
 use crate::runtime::{EvalContext, Output, Pattern, RuntimeError};
 use crate::runtime::{PackagePath, World};
@@ -13,6 +13,7 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::pin::Pin;
 
+use crate::runtime::rationale::Rationale;
 use serde_json::json;
 use std::sync::Arc;
 
@@ -107,10 +108,18 @@ impl Function for Base64 {
                     Ok(Output::Transform(Arc::new(decoded.into())).into())
                 } else {
                     //Err(FunctionError::Other("unable to decode base64".into()))
-                    Ok(Output::None.into())
+                    Ok((
+                        Severity::Error,
+                        Rationale::InvalidArgument("Invalid base64 encoding".to_string()),
+                    )
+                        .into())
                 }
             } else {
-                Ok(Output::None.into())
+                Ok((
+                    Severity::Error,
+                    Rationale::InvalidArgument("Expected a string".to_string()),
+                )
+                    .into())
             }
         })
     }
@@ -141,7 +150,7 @@ impl Function for Base64Encode {
 
                 Ok(Output::Transform(Arc::new(result.into())).into())
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/config/of.rs
+++ b/engine/src/core/config/of.rs
@@ -1,7 +1,7 @@
 use crate::core::{Function, FunctionEvaluationResult};
 use crate::lang::lir::Bindings;
-use crate::lang::PatternMeta;
 use crate::lang::ValuePattern;
+use crate::lang::{PatternMeta, Severity};
 use crate::runtime::{EvalContext, Output, RuntimeError, World};
 use crate::value::RuntimeValue;
 use std::future::Future;
@@ -44,13 +44,13 @@ impl Function for Of {
                     if let Some(value) = ctx.config().get(&key) {
                         Ok(Output::Transform(Arc::new(value.into())).into())
                     } else {
-                        Ok(Output::None.into())
+                        Ok(Severity::Error.into())
                     }
                 } else {
-                    Ok(Output::None.into())
+                    Ok(Severity::Error.into())
                 }
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/csaf/mod.rs
+++ b/engine/src/core/csaf/mod.rs
@@ -9,7 +9,7 @@ pub fn package() -> Package {
 
 #[cfg(test)]
 mod test {
-
+    use crate::lang::Severity;
     use crate::runtime::testutil::test_pattern;
 
     #[tokio::test]
@@ -18,6 +18,6 @@ mod test {
         let json: serde_json::Value = serde_json::from_str(input).unwrap();
         let result = test_pattern(r#"csaf::csaf"#, json).await;
 
-        assert!(result.satisfied());
+        assert_eq!(result.severity(), Severity::None);
     }
 }

--- a/engine/src/core/cyclonedx/mod.rs
+++ b/engine/src/core/cyclonedx/mod.rs
@@ -9,7 +9,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 pub fn package() -> Package {
@@ -60,7 +60,7 @@ impl Function for ComponentPurls {
                     }
                     Ok(Output::Transform(Arc::new(RuntimeValue::List(purls))).into())
                 }
-                _ => Ok(Output::None.into()),
+                _ => Ok(Severity::None.into()),
             }
         })
     }

--- a/engine/src/core/data/from.rs
+++ b/engine/src/core/data/from.rs
@@ -6,7 +6,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 #[allow(clippy::upper_case_acronyms)]
@@ -65,7 +65,7 @@ impl Function for From {
                 }
             }
 
-            Ok(Output::None.into())
+            Ok(Severity::Error.into())
         })
     }
 }

--- a/engine/src/core/data/lookup.rs
+++ b/engine/src/core/data/lookup.rs
@@ -6,7 +6,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 #[allow(clippy::upper_case_acronyms)]
@@ -71,31 +71,31 @@ impl Function for Lookup {
                                                 if let Some(next) = obj.get(step) {
                                                     current = next;
                                                 } else {
-                                                    return Ok(Output::None.into());
+                                                    return Ok(Severity::Error.into());
                                                 }
                                             } else {
-                                                return Ok(Output::None.into());
+                                                return Ok(Severity::Error.into());
                                             }
                                         } else {
-                                            return Ok(Output::None.into());
+                                            return Ok(Severity::Error.into());
                                         }
                                     }
                                     return Ok(Output::Transform(current).into());
                                 } else {
                                     //todo!("support single non-list lookups")
-                                    return Ok(Output::None.into());
+                                    return Ok(Severity::Error.into());
                                 }
                             } else {
-                                return Ok(Output::None.into());
+                                return Ok(Severity::Error.into());
                             }
                         }
                     }
-                    Ok(Output::None.into())
+                    Ok(Severity::Error.into())
                 } else {
-                    Ok(Output::None.into())
+                    Ok(Severity::Error.into())
                 }
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/debug/delay.rs
+++ b/engine/src/core/debug/delay.rs
@@ -1,7 +1,7 @@
 use crate::core::{Function, FunctionEvaluationResult};
 use crate::lang::{
     lir::{Bindings, ValuePattern},
-    PatternMeta,
+    PatternMeta, Severity,
 };
 use crate::runtime::{EvalContext, Output, RuntimeError, World};
 use crate::value::RuntimeValue;
@@ -48,7 +48,7 @@ impl Function for DelayMs {
                 }
             }
 
-            Ok(Output::None.into())
+            Ok(Severity::None.into())
         })
     }
 }

--- a/engine/src/core/external/eval.rs
+++ b/engine/src/core/external/eval.rs
@@ -1,7 +1,7 @@
 use crate::core::{Function, FunctionEvaluationResult};
 use crate::lang::lir::Bindings;
-use crate::lang::PatternMeta;
 use crate::lang::ValuePattern;
+use crate::lang::{PatternMeta, Severity};
 use crate::runtime::{EvalContext, Output, RuntimeError, World};
 use crate::value::RuntimeValue;
 use serde_json::Value;
@@ -62,36 +62,36 @@ impl Function for Eval {
                                             if let Ok(output) = output {
                                                 let output: RuntimeValue = output.into();
                                                 if *input.as_ref() == output {
-                                                    Ok(Output::Identity.into())
+                                                    Ok(Severity::None.into())
                                                 } else {
                                                     Ok(Output::Transform(Arc::new(output)).into())
                                                 }
                                             } else {
-                                                Ok(Output::Identity.into())
+                                                Ok(Severity::None.into())
                                             }
                                         } else {
-                                            Ok(Output::Identity.into())
+                                            Ok(Severity::None.into())
                                         }
                                     } else {
-                                        Ok(Output::Identity.into())
+                                        Ok(Severity::None.into())
                                     }
                                 } else {
-                                    Ok(Output::Identity.into())
+                                    Ok(Severity::None.into())
                                 }
                             } else {
-                                Ok(Output::None.into())
+                                Ok(Severity::Error.into())
                             }
                         } else {
-                            Ok(Output::None.into())
+                            Ok(Severity::Error.into())
                         }
                     } else {
-                        Ok(Output::None.into())
+                        Ok(Severity::Error.into())
                     }
                 } else {
-                    Ok(Output::None.into())
+                    Ok(Severity::Error.into())
                 }
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/guac/certify_vuln.rs
+++ b/engine/src/core/guac/certify_vuln.rs
@@ -8,7 +8,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use guac_rs::client::{certify_vuln::*, GuacClient};
 use std::sync::Arc;
 
@@ -105,7 +105,7 @@ impl Function for CertifyVuln {
         Box::pin(async move {
             match CertifyVuln::from_purls(input.as_json()).await {
                 Ok(Some(json)) => Ok(Output::Transform(Arc::new(json.into())).into()),
-                _ => Ok(Output::None.into()),
+                _ => Ok(Severity::Error.into()),
             }
         })
     }

--- a/engine/src/core/guac/certify_vuln.rs
+++ b/engine/src/core/guac/certify_vuln.rs
@@ -22,19 +22,11 @@ fn json_to_pkg(input: serde_json::Value) -> Option<PkgSpec> {
     match input {
         JsonValue::Object(input) => {
             let pkg = PkgSpec {
-                type_: input
-                    .get("type")
-                    .map_or(None, |val| Some(val.as_str()?.to_string())),
-                namespace: input
-                    .get("namespace")
-                    .map_or(None, |val| Some(val.as_str()?.to_string())),
-                name: input
-                    .get("name")
-                    .map_or(None, |val| Some(val.as_str()?.to_string())),
+                type_: input.get("type").map(|val| val.to_string()),
+                namespace: input.get("namespace").map(|val| val.to_string()),
+                name: input.get("name").map(|val| val.to_string()),
                 subpath: None,
-                version: input
-                    .get("version")
-                    .map_or(None, |val| Some(val.as_str()?.to_string())),
+                version: input.get("version").map(|val| val.to_string()),
                 qualifiers: None, //TODO fix qualifiers
                 match_only_empty_qualifiers: Some(false),
             };
@@ -58,8 +50,8 @@ impl CertifyVuln {
             JsonValue::Array(items) => {
                 let mut vulns = Vec::new();
                 for item in items.iter() {
-                    match json_to_pkg(item.clone()) {
-                        Some(value) => match guac.certify_vuln(value).await {
+                    if let Some(value) = json_to_pkg(item.clone()) {
+                        match guac.certify_vuln(value).await {
                             Ok(transform) => {
                                 let json: serde_json::Value =
                                     serde_json::to_value(transform).unwrap();
@@ -68,8 +60,7 @@ impl CertifyVuln {
                             Err(e) => {
                                 log::warn!("Error looking up {:?}", e);
                             }
-                        },
-                        _ => {}
+                        }
                     }
                 }
                 let json: serde_json::Value = serde_json::to_value(vulns).unwrap();

--- a/engine/src/core/intoto/envelope.rs
+++ b/engine/src/core/intoto/envelope.rs
@@ -288,12 +288,12 @@ fn get_attesters(param: &str, bindings: &Bindings) -> HashMap<String, String> {
 
 fn base64_decode_error(field: impl Into<String>) -> Result<FunctionEvaluationResult, RuntimeError> {
     let msg = format!("Could not decode {} field to base64", field.into());
-    Ok((Severity::Error, Rationale::InvalidArgument(msg.into())).into())
+    Ok((Severity::Error, Rationale::InvalidArgument(msg)).into())
 }
 
 fn json_parse_error(field: impl Into<String>) -> Result<FunctionEvaluationResult, RuntimeError> {
     let msg = format!("Could not parse {}", field.into());
-    Ok((Severity::Error, Rationale::InvalidArgument(msg.into())).into())
+    Ok((Severity::Error, Rationale::InvalidArgument(msg)).into())
 }
 
 fn missing_attesters() -> Result<FunctionEvaluationResult, RuntimeError> {
@@ -311,7 +311,7 @@ fn invalid_type(
     value: impl Into<String>,
 ) -> Result<FunctionEvaluationResult, RuntimeError> {
     let msg = format!("invalid {} specified {}", field.into(), value.into());
-    Ok((Severity::Error, Rationale::InvalidArgument(msg.into())).into())
+    Ok((Severity::Error, Rationale::InvalidArgument(msg)).into())
 }
 
 #[cfg(test)]

--- a/engine/src/core/intoto/mod.rs
+++ b/engine/src/core/intoto/mod.rs
@@ -14,12 +14,13 @@ pub fn package() -> Package {
 
 #[cfg(test)]
 mod test {
+    use crate::assert_satisfied;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
     use crate::runtime::EvalContext;
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn envelope() {
         let src = Ephemeral::new(
             "test",
@@ -43,9 +44,10 @@ mod test {
         });
         let result = runtime
             .evaluate("test::envelope", input, EvalContext::default())
-            .await;
+            .await
+            .unwrap();
         //println!("result: {:?}", result);
-        assert!(result.as_ref().unwrap().satisfied());
+        assert_satisfied!(result);
 
         //let _output = result.unwrap().output().unwrap();
     }

--- a/engine/src/core/json/mod.rs
+++ b/engine/src/core/json/mod.rs
@@ -62,9 +62,10 @@ mod test {
     use super::*;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
+    use crate::{assert_not_satisfied, assert_satisfied};
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_parseable() {
         let src = Ephemeral::new(
             "test",
@@ -89,13 +90,13 @@ mod test {
 
         let result = runtime
             .evaluate("test::test-json", value, EvalContext::default())
-            .await;
+            .await
+            .unwrap();
 
-        assert!(result.unwrap().satisfied())
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
+        assert_satisfied!(result);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nonparseable() {
         let src = Ephemeral::new(
             "test",
@@ -116,9 +117,9 @@ mod test {
 
         let result = runtime
             .evaluate("test::test-json", value, EvalContext::default())
-            .await;
+            .await
+            .unwrap();
 
-        //assert!(matches!(result, Ok(RationaleResult::None),))
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result);
     }
 }

--- a/engine/src/core/json/mod.rs
+++ b/engine/src/core/json/mod.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 pub fn package() -> Package {
@@ -48,10 +48,10 @@ impl Function for JSON {
                 if let Ok(json_value) = json_value {
                     Ok(Output::Transform(Arc::new(json_value.into())).into())
                 } else {
-                    Ok(Output::None.into())
+                    Ok(Severity::Error.into())
                 }
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/lang/and.rs
+++ b/engine/src/core/lang/and.rs
@@ -64,9 +64,10 @@ mod test {
     use super::*;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
+    use crate::{assert_not_satisfied, assert_satisfied};
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_both_arms() {
         let src = Ephemeral::new(
             "test",
@@ -98,11 +99,13 @@ mod test {
                 ),
                 EvalContext::default(),
             )
-            .await;
-        assert!(result.unwrap().satisfied())
+            .await
+            .unwrap();
+
+        assert_satisfied!(result);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_only_left_arm() {
         let src = Ephemeral::new(
             "test",
@@ -134,11 +137,13 @@ mod test {
                 ),
                 EvalContext::default(),
             )
-            .await;
-        assert!(!result.unwrap().satisfied())
+            .await
+            .unwrap();
+
+        assert_not_satisfied!(result);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_only_right_arm() {
         let src = Ephemeral::new(
             "test",
@@ -170,11 +175,13 @@ mod test {
                 ),
                 EvalContext::default(),
             )
-            .await;
-        assert!(!result.unwrap().satisfied())
+            .await
+            .unwrap();
+
+        assert_not_satisfied!(result);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_no_arms() {
         let src = Ephemeral::new(
             "test",
@@ -207,7 +214,9 @@ mod test {
                 ),
                 EvalContext::default(),
             )
-            .await;
-        assert!(!result.unwrap().satisfied())
+            .await
+            .unwrap();
+
+        assert_not_satisfied!(result);
     }
 }

--- a/engine/src/core/lang/not.rs
+++ b/engine/src/core/lang/not.rs
@@ -51,12 +51,11 @@ impl Function for Not {
 
 #[cfg(test)]
 mod test {
-
     use crate::runtime::testutil::test_pattern;
-
+    use crate::{assert_not_satisfied, assert_satisfied};
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_not_matching() {
         let result = test_pattern(
             r#"
@@ -66,10 +65,10 @@ mod test {
         )
         .await;
 
-        assert!(!result.satisfied())
+        assert_not_satisfied!(result);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching() {
         let result = test_pattern(
             r#"
@@ -79,6 +78,6 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 }

--- a/engine/src/core/lang/or.rs
+++ b/engine/src/core/lang/or.rs
@@ -98,11 +98,12 @@ impl Function for Or {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::assert_satisfied;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn list_operation() {
         let src = Ephemeral::new(
             "test",
@@ -121,8 +122,9 @@ mod test {
 
         let result = runtime
             .evaluate("test::test-or", value, EvalContext::default())
-            .await;
+            .await
+            .unwrap();
 
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result);
     }
 }

--- a/engine/src/core/lang/traverse.rs
+++ b/engine/src/core/lang/traverse.rs
@@ -5,7 +5,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 const DOCUMENTATION: &str = include_str!("traverse.adoc");
@@ -45,7 +45,7 @@ impl Function for Traverse {
                 }
             }
 
-            Ok(Output::None.into())
+            Ok(Severity::Error.into())
         })
     }
 }

--- a/engine/src/core/list/all.rs
+++ b/engine/src/core/list/all.rs
@@ -60,9 +60,10 @@ mod test {
     use super::*;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
+    use crate::{assert_not_satisfied, assert_satisfied};
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_homogenous_literal() {
         let src = Ephemeral::new(
             "test",
@@ -81,13 +82,13 @@ mod test {
 
         let result = runtime
             .evaluate("test::test-all", value, EvalContext::default())
-            .await;
+            .await
+            .unwrap();
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_homogenous_type() {
         let src = Ephemeral::new(
             "test",
@@ -106,13 +107,13 @@ mod test {
 
         let result = runtime
             .evaluate("test::test-all", value, EvalContext::default())
-            .await;
+            .await
+            .unwrap();
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nonmatching_homogenous_literal() {
         let src = Ephemeral::new(
             "test",
@@ -131,13 +132,13 @@ mod test {
 
         let result = runtime
             .evaluate("test::test-all", value, EvalContext::default())
-            .await;
+            .await
+            .unwrap();
 
-        //assert!(matches!(result, Ok(RationaleResult::None),))
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nonmatching_homogenous_type() {
         let src = Ephemeral::new(
             "test",
@@ -156,12 +157,13 @@ mod test {
 
         let result = runtime
             .evaluate("test::test-all", value, EvalContext::default())
-            .await;
+            .await
+            .unwrap();
 
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_empty() {
         let src = Ephemeral::new(
             "test",
@@ -180,9 +182,9 @@ mod test {
 
         let result = runtime
             .evaluate("test::test-all", value, EvalContext::default())
-            .await;
+            .await
+            .unwrap();
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result);
     }
 }

--- a/engine/src/core/list/all.rs
+++ b/engine/src/core/list/all.rs
@@ -1,13 +1,13 @@
-use crate::core::list::PATTERN;
-use crate::core::{Function, FunctionEvaluationResult};
+use crate::core::{list::PATTERN, Function, FunctionEvaluationResult};
 use crate::lang::lir::Bindings;
-use crate::runtime::{EvalContext, Output, RuntimeError, World};
+use crate::runtime::{EvalContext, RuntimeError, World};
 use crate::value::RuntimeValue;
 
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
+use crate::runtime::rationale::Rationale;
 use std::sync::Arc;
 
 const DOCUMENTATION: &str = include_str!("all.adoc");
@@ -46,13 +46,10 @@ impl Function for All {
                     );
                 }
 
-                if supporting.iter().all(|e| e.satisfied()) {
-                    Ok((Output::Identity, supporting).into())
-                } else {
-                    Ok((Output::None, supporting).into())
-                }
+                let severity = supporting.iter().map(|s| s.severity()).collect();
+                Ok((severity, supporting).into())
             } else {
-                Ok(Output::None.into())
+                Ok((Severity::Error, Rationale::NotAList).into())
             }
         })
     }

--- a/engine/src/core/list/any.rs
+++ b/engine/src/core/list/any.rs
@@ -1,5 +1,4 @@
-use crate::core::list::PATTERN;
-use crate::core::{Function, FunctionEvaluationResult};
+use crate::core::{list::PATTERN, Function, FunctionEvaluationResult};
 use crate::lang::lir::Bindings;
 use crate::runtime::{EvalContext, RuntimeError, World};
 use crate::value::RuntimeValue;
@@ -64,9 +63,10 @@ mod test {
     use super::*;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
+    use crate::{assert_not_satisfied, assert_satisfied};
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_homogenous_literal() {
         let src = Ephemeral::new(
             "test",
@@ -87,11 +87,10 @@ mod test {
             .evaluate("test::test-any", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_homogenous_type() {
         let src = Ephemeral::new(
             "test",
@@ -112,11 +111,10 @@ mod test {
             .evaluate("test::test-any", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nonmatching_homogenous_literal() {
         let src = Ephemeral::new(
             "test",
@@ -137,10 +135,10 @@ mod test {
             .evaluate("test::test-any", value, EvalContext::default())
             .await;
 
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nonmatching_homogenous_type() {
         let src = Ephemeral::new(
             "test",
@@ -161,11 +159,10 @@ mod test {
             .evaluate("test::test-any", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::None),))
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_heterogenous_literal() {
         let src = Ephemeral::new(
             "test",
@@ -186,11 +183,10 @@ mod test {
             .evaluate("test::test-any", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_heterogenous_type() {
         let src = Ephemeral::new(
             "test",
@@ -211,11 +207,10 @@ mod test {
             .evaluate("test::test-any", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nonmatching_heterogenous_literal() {
         let src = Ephemeral::new(
             "test",
@@ -236,11 +231,10 @@ mod test {
             .evaluate("test::test-any", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::None),))
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nonmatching_empty() {
         let src = Ephemeral::new(
             "test",
@@ -261,11 +255,10 @@ mod test {
             .evaluate("test::test-any", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::None),))
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nested() {
         let src = Ephemeral::new(
             "test",
@@ -288,7 +281,6 @@ mod test {
             .evaluate("test::test-any", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::None),))
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result.unwrap());
     }
 }

--- a/engine/src/core/list/any.rs
+++ b/engine/src/core/list/any.rs
@@ -1,13 +1,14 @@
 use crate::core::list::PATTERN;
 use crate::core::{Function, FunctionEvaluationResult};
 use crate::lang::lir::Bindings;
-use crate::runtime::{EvalContext, Output, RuntimeError, World};
+use crate::runtime::{EvalContext, RuntimeError, World};
 use crate::value::RuntimeValue;
 
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
+use crate::runtime::rationale::Rationale;
 use std::sync::Arc;
 
 const DOCUMENTATION: &str = include_str!("any.adoc");
@@ -46,13 +47,13 @@ impl Function for Any {
                     );
                 }
 
-                if supporting.iter().any(|e| e.satisfied()) {
-                    Ok((Output::Identity, supporting).into())
-                } else {
-                    Ok((Output::None, supporting).into())
-                }
+                let severity = match supporting.iter().any(|e| e.severity() < Severity::Error) {
+                    true => Severity::None,
+                    false => Severity::Error,
+                };
+                Ok((severity, supporting).into())
             } else {
-                Ok(Output::None.into())
+                Ok((Severity::Error, Rationale::NotAList).into())
             }
         })
     }

--- a/engine/src/core/list/concat.rs
+++ b/engine/src/core/list/concat.rs
@@ -119,14 +119,10 @@ mod test {
         let result = test_pattern(r#"list::concat<"some string">"#, json!([1, 2, 3])).await;
         assert_not_satisfied!(result);
 
-        match result.rationale() {
-            Rationale::Function(_, out, _) => match &**(out.as_ref().unwrap()) {
-                Rationale::InvalidArgument(msg) => {
-                    assert_eq!(msg, "invalid type specified for list parameter")
-                }
-                _ => {}
-            },
-            _ => {}
+        if let Rationale::Function(_, out, _) = result.rationale() {
+            if let Rationale::InvalidArgument(msg) = &**(out.as_ref().unwrap()) {
+                assert_eq!(msg, "invalid type specified for list parameter")
+            }
         }
     }
 }

--- a/engine/src/core/list/concat.rs
+++ b/engine/src/core/list/concat.rs
@@ -6,7 +6,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 const DOCUMENTATION: &str = include_str!("concat.adoc");
@@ -76,7 +76,7 @@ fn get_parameter(param: &str, bindings: &Bindings) -> Result<Vec<Arc<RuntimeValu
 }
 
 fn invalid_arg(msg: impl Into<String>) -> Result<FunctionEvaluationResult, RuntimeError> {
-    Ok((Output::None, Rationale::InvalidArgument(msg.into())).into())
+    Ok((Severity::Error, Rationale::InvalidArgument(msg.into())).into())
 }
 
 #[cfg(test)]

--- a/engine/src/core/list/contains.rs
+++ b/engine/src/core/list/contains.rs
@@ -6,7 +6,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 const DOCUMENTATION: &str = include_str!("contains-all.adoc");
@@ -58,7 +58,7 @@ impl Function for ContainsAll {
                                     }
                                 }
                                 if !found {
-                                    return Ok(Output::None.into());
+                                    return Ok(Severity::Error.into());
                                 }
                             } else {
                                 return Err(RuntimeError::InvalidState);
@@ -68,7 +68,7 @@ impl Function for ContainsAll {
                     }
                 }
             }
-            Ok(Output::None.into())
+            Ok(Severity::Error.into())
         })
     }
 }

--- a/engine/src/core/list/count.rs
+++ b/engine/src/core/list/count.rs
@@ -48,24 +48,24 @@ mod test {
     use crate::{assert_satisfied, runtime::testutil::test_pattern};
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn list_count() {
         let result = test_pattern(r#"list::count( $(self == 4) )"#, json!([1, 2, 3, 4])).await;
-        assert_satisfied!(result);
-        assert_eq!(result.output().unwrap().try_get_integer().unwrap(), 4);
+        assert_satisfied!(&result);
+        assert_eq!(result.output().try_get_integer().unwrap(), 4);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn list_length() {
         let result = test_pattern(r#"list::count( $(self == 2) )"#, json!([1, 2])).await;
-        assert_satisfied!(result);
-        assert_eq!(result.output().unwrap().try_get_integer().unwrap(), 2);
+        assert_satisfied!(&result);
+        assert_eq!(result.output().try_get_integer().unwrap(), 2);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn list_count_none_list() {
         let result = test_pattern(r#"list::count( $(self == 0) )"#, json!(123)).await;
-        assert_satisfied!(result);
-        assert_eq!(result.output().unwrap().try_get_integer().unwrap(), 0);
+        assert_satisfied!(&result);
+        assert_eq!(result.output().try_get_integer().unwrap(), 0);
     }
 }

--- a/engine/src/core/list/filter.rs
+++ b/engine/src/core/list/filter.rs
@@ -75,10 +75,7 @@ mod test {
     async fn list_filter() {
         let json = serde_json::json!([1, 2, "foo"]);
         let result = test_pattern(r#"list::filter<integer>"#, json).await;
-        assert_satisfied!(result);
-        assert_eq!(
-            result.output().unwrap().as_json(),
-            serde_json::json!([1, 2])
-        );
+        assert_satisfied!(&result);
+        assert_eq!(result.output().as_json(), serde_json::json!([1, 2]));
     }
 }

--- a/engine/src/core/list/head.rs
+++ b/engine/src/core/list/head.rs
@@ -57,6 +57,7 @@ impl Function for Head {
 mod test {
     use crate::runtime::testutil::*;
 
+    use crate::assert_satisfied;
     use serde_json::json;
 
     #[tokio::test]
@@ -70,7 +71,7 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 
     #[tokio::test]
@@ -84,7 +85,7 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 
     #[tokio::test]
@@ -98,7 +99,7 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 
     #[tokio::test]
@@ -112,7 +113,7 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 
     #[tokio::test]
@@ -126,7 +127,7 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 
     #[tokio::test]
@@ -140,6 +141,6 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 }

--- a/engine/src/core/list/head.rs
+++ b/engine/src/core/list/head.rs
@@ -7,7 +7,8 @@ use crate::value::{Object, RuntimeValue};
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
+use crate::runtime::rationale::Rationale;
 use std::sync::Arc;
 
 const DOCUMENTATION: &str = include_str!("head.adoc");
@@ -46,7 +47,7 @@ impl Function for Head {
 
                 Ok(Output::Transform(Arc::new(result.into())).into())
             } else {
-                Ok(Output::None.into())
+                Ok((Severity::Error, Rationale::NotAList).into())
             }
         })
     }

--- a/engine/src/core/list/map.rs
+++ b/engine/src/core/list/map.rs
@@ -102,7 +102,7 @@ mod tests {
 
         assert_eq!(
             result.output(),
-            Some(Arc::new(
+            Arc::new(
                 json!([{
                     "type": "github",
                     "namespace": "package-url",
@@ -112,7 +112,7 @@ mod tests {
                 }, null,
                 ])
                 .into()
-            ))
+            )
         );
     }
 
@@ -135,7 +135,7 @@ mod tests {
 
         assert_eq!(
             result.output(),
-            Some(Arc::new(
+            Arc::new(
                 json!([{
                     "type": "github",
                     "namespace": "package-url",
@@ -150,7 +150,7 @@ mod tests {
                     "subpath": "everybody/loves/cats",
                 }])
                 .into()
-            ))
+            )
         );
     }
 }

--- a/engine/src/core/list/mod.rs
+++ b/engine/src/core/list/mod.rs
@@ -1,3 +1,4 @@
+use crate::lang::Severity;
 use crate::runtime::EvalContext;
 use crate::{
     lang::lir::Pattern,
@@ -42,6 +43,10 @@ pub fn package() -> Package {
     pkg
 }
 
+/// Split a list of values at given predicate.
+///
+/// This takes an iterator of values, splitting it in two lists. Filling the first one until the
+/// pattern in `count` is satisfied. Adding the remainder to the second one.
 pub(crate) async fn split_fill<I>(
     ctx: &EvalContext,
     world: &World,
@@ -64,7 +69,7 @@ where
                         world,
                     )
                     .await?;
-                expected_result.satisfied()
+                !matches!(expected_result.severity(), Severity::Error)
             }
             None => !greedy.is_empty(),
         };

--- a/engine/src/core/list/none.rs
+++ b/engine/src/core/list/none.rs
@@ -1,13 +1,9 @@
-use crate::core::list::PATTERN;
-use crate::core::{Function, FunctionEvaluationResult};
-use crate::lang::lir::Bindings;
-use crate::runtime::{EvalContext, World};
-use crate::runtime::{Output, RuntimeError};
+use crate::core::{list::PATTERN, Function, FunctionEvaluationResult};
+use crate::lang::{lir::Bindings, Severity};
+use crate::runtime::{rationale::Rationale, EvalContext, RuntimeError, World};
 use crate::value::RuntimeValue;
-
 use std::future::Future;
 use std::pin::Pin;
-
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -37,13 +33,12 @@ impl Function for None {
                     );
                 }
 
-                if supporting.iter().all(|e| !e.satisfied()) {
-                    Ok((Output::Identity, supporting).into())
-                } else {
-                    Ok(Output::None.into())
+                match supporting.iter().all(|e| e.severity() == Severity::Error) {
+                    true => Ok((Severity::None, supporting).into()),
+                    false => Ok((Severity::Error, supporting).into()),
                 }
             } else {
-                Ok(Output::None.into())
+                Ok((Severity::Error, Rationale::NotAList).into())
             }
         })
     }

--- a/engine/src/core/list/none.rs
+++ b/engine/src/core/list/none.rs
@@ -49,9 +49,10 @@ mod test {
     use super::*;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
+    use crate::{assert_not_satisfied, assert_satisfied};
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_homogenous_literal() {
         let src = Ephemeral::new(
             "test",
@@ -72,11 +73,10 @@ mod test {
             .evaluate("test::test-none", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_homogenous_type() {
         let src = Ephemeral::new(
             "test",
@@ -97,11 +97,10 @@ mod test {
             .evaluate("test::test-none", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nonmatching_homogenous_literal() {
         let src = Ephemeral::new(
             "test",
@@ -122,11 +121,10 @@ mod test {
             .evaluate("test::test-none", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::None),))
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nonmatching_homogenous_type() {
         let src = Ephemeral::new(
             "test",
@@ -147,11 +145,10 @@ mod test {
             .evaluate("test::test-none", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::None)))
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nonmatching_heterogenous_type() {
         let src = Ephemeral::new(
             "test",
@@ -172,11 +169,10 @@ mod test {
             .evaluate("test::test-none", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::None),))
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_heterogenous_literal() {
         let src = Ephemeral::new(
             "test",
@@ -197,11 +193,10 @@ mod test {
             .evaluate("test::test-none", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_empty() {
         let src = Ephemeral::new(
             "test",
@@ -222,7 +217,6 @@ mod test {
             .evaluate("test::test-none", value, EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result.unwrap());
     }
 }

--- a/engine/src/core/list/slice.rs
+++ b/engine/src/core/list/slice.rs
@@ -84,9 +84,10 @@ mod test {
     use super::*;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
+    use crate::{assert_not_satisfied, assert_satisfied};
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn list_slice() {
         let src = Ephemeral::new(
             "test",
@@ -100,17 +101,18 @@ mod test {
         let runtime = builder.finish().await.unwrap();
         let result = runtime
             .evaluate("test::sl", json!([1, 2, 3, 4, 5]), EvalContext::default())
-            .await;
-        assert!(result.as_ref().unwrap().satisfied());
+            .await
+            .unwrap();
+        assert_satisfied!(&result);
 
-        let output = result.unwrap().output().unwrap();
+        let output = result.output();
         let list = output.try_get_list().unwrap();
         assert_eq!(list.len(), 2);
         assert!(list.contains(&Arc::new(RuntimeValue::Integer(3))));
         assert!(list.contains(&Arc::new(RuntimeValue::Integer(4))));
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn list_slice_invalid_start_index() {
         let src = Ephemeral::new(
             "test",
@@ -124,16 +126,25 @@ mod test {
         let runtime = builder.finish().await.unwrap();
         let result = runtime
             .evaluate("test::sl", json!([1, 2, 3, 4, 5]), EvalContext::default())
-            .await;
-        assert!(!result.as_ref().unwrap().satisfied());
-        if let Rationale::Function(_, out, _) = result.as_ref().unwrap().rationale() {
-            if let Rationale::InvalidArgument(msg) = &**(out.as_ref().unwrap()) {
-                assert_eq!(msg, "invalid start index specified")
-            }
+            .await
+            .unwrap();
+        assert_not_satisfied!(&result);
+        match result.rationale() {
+            Rationale::Function {
+                severity: _,
+                rationale: out,
+                supporting: _,
+            } => match &**(out.as_ref().unwrap()) {
+                Rationale::InvalidArgument(msg) => {
+                    assert_eq!(msg, "invalid start index specified")
+                }
+                _ => {}
+            },
+            _ => {}
         }
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn list_slice_invalid_end_index() {
         let src = Ephemeral::new(
             "test",
@@ -147,16 +158,25 @@ mod test {
         let runtime = builder.finish().await.unwrap();
         let result = runtime
             .evaluate("test::sl", json!([1, 2, 3, 4, 5]), EvalContext::default())
-            .await;
-        assert!(!result.as_ref().unwrap().satisfied());
-        if let Rationale::Function(_, out, _) = result.as_ref().unwrap().rationale() {
-            if let Rationale::InvalidArgument(msg) = &**(out.as_ref().unwrap()) {
-                assert_eq!(msg, "invalid end index specified")
-            }
+            .await
+            .unwrap();
+        assert_not_satisfied!(&result);
+        match result.rationale() {
+            Rationale::Function {
+                severity: _,
+                rationale: out,
+                supporting: _,
+            } => match &**(out.as_ref().unwrap()) {
+                Rationale::InvalidArgument(msg) => {
+                    assert_eq!(msg, "invalid end index specified")
+                }
+                _ => {}
+            },
+            _ => {}
         }
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn list_slice_invalid_index() {
         let src = Ephemeral::new(
             "test",
@@ -170,12 +190,21 @@ mod test {
         let runtime = builder.finish().await.unwrap();
         let result = runtime
             .evaluate("test::sl", json!([1, 2, 3, 4, 5]), EvalContext::default())
-            .await;
-        assert!(!result.as_ref().unwrap().satisfied());
-        if let Rationale::Function(_, out, _) = result.as_ref().unwrap().rationale() {
-            if let Rationale::InvalidArgument(msg) = &**(out.as_ref().unwrap()) {
-                assert_eq!(msg, "start index cannot be greater than end index")
-            }
+            .await
+            .unwrap();
+        assert_not_satisfied!(&result);
+        match result.rationale() {
+            Rationale::Function {
+                severity: _,
+                rationale: out,
+                supporting: _,
+            } => match &**(out.as_ref().unwrap()) {
+                Rationale::InvalidArgument(msg) => {
+                    assert_eq!(msg, "start index cannot be greater than end index")
+                }
+                _ => {}
+            },
+            _ => {}
         }
     }
 }

--- a/engine/src/core/list/slice.rs
+++ b/engine/src/core/list/slice.rs
@@ -126,14 +126,10 @@ mod test {
             .evaluate("test::sl", json!([1, 2, 3, 4, 5]), EvalContext::default())
             .await;
         assert!(!result.as_ref().unwrap().satisfied());
-        match result.as_ref().unwrap().rationale() {
-            Rationale::Function(_, out, _) => match &**(out.as_ref().unwrap()) {
-                Rationale::InvalidArgument(msg) => {
-                    assert_eq!(msg, "invalid start index specified")
-                }
-                _ => {}
-            },
-            _ => {}
+        if let Rationale::Function(_, out, _) = result.as_ref().unwrap().rationale() {
+            if let Rationale::InvalidArgument(msg) = &**(out.as_ref().unwrap()) {
+                assert_eq!(msg, "invalid start index specified")
+            }
         }
     }
 
@@ -153,14 +149,10 @@ mod test {
             .evaluate("test::sl", json!([1, 2, 3, 4, 5]), EvalContext::default())
             .await;
         assert!(!result.as_ref().unwrap().satisfied());
-        match result.as_ref().unwrap().rationale() {
-            Rationale::Function(_, out, _) => match &**(out.as_ref().unwrap()) {
-                Rationale::InvalidArgument(msg) => {
-                    assert_eq!(msg, "invalid end index specified")
-                }
-                _ => {}
-            },
-            _ => {}
+        if let Rationale::Function(_, out, _) = result.as_ref().unwrap().rationale() {
+            if let Rationale::InvalidArgument(msg) = &**(out.as_ref().unwrap()) {
+                assert_eq!(msg, "invalid end index specified")
+            }
         }
     }
 
@@ -180,14 +172,10 @@ mod test {
             .evaluate("test::sl", json!([1, 2, 3, 4, 5]), EvalContext::default())
             .await;
         assert!(!result.as_ref().unwrap().satisfied());
-        match result.as_ref().unwrap().rationale() {
-            Rationale::Function(_, out, _) => match &**(out.as_ref().unwrap()) {
-                Rationale::InvalidArgument(msg) => {
-                    assert_eq!(msg, "start index cannot be greater than end index")
-                }
-                _ => {}
-            },
-            _ => {}
+        if let Rationale::Function(_, out, _) = result.as_ref().unwrap().rationale() {
+            if let Rationale::InvalidArgument(msg) = &**(out.as_ref().unwrap()) {
+                assert_eq!(msg, "start index cannot be greater than end index")
+            }
         }
     }
 }

--- a/engine/src/core/list/slice.rs
+++ b/engine/src/core/list/slice.rs
@@ -1,5 +1,5 @@
 use crate::core::{Function, FunctionEvaluationResult};
-use crate::lang::ValuePattern;
+use crate::lang::{Severity, ValuePattern};
 use crate::runtime::rationale::Rationale;
 //use crate::lang::lir::{Bindings, InnerPattern, ValuePattern};
 use crate::lang::lir::{Bindings, InnerPattern};
@@ -76,7 +76,7 @@ fn get_parameter(param: &str, bindings: &Bindings) -> Result<usize, String> {
 }
 
 fn invalid_arg(msg: impl Into<String>) -> Result<FunctionEvaluationResult, RuntimeError> {
-    Ok((Output::None, Rationale::InvalidArgument(msg.into())).into())
+    Ok((Severity::Error, Rationale::InvalidArgument(msg.into())).into())
 }
 
 #[cfg(test)]

--- a/engine/src/core/list/tail.rs
+++ b/engine/src/core/list/tail.rs
@@ -59,6 +59,7 @@ impl Function for Tail {
 mod test {
     use crate::runtime::testutil::*;
 
+    use crate::assert_satisfied;
     use serde_json::json;
 
     #[tokio::test]
@@ -72,7 +73,7 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 
     #[tokio::test]
@@ -86,7 +87,7 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 
     #[tokio::test]
@@ -100,7 +101,7 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 
     #[tokio::test]
@@ -114,7 +115,7 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 
     #[tokio::test]
@@ -128,7 +129,7 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 
     #[tokio::test]
@@ -142,6 +143,6 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 }

--- a/engine/src/core/list/tail.rs
+++ b/engine/src/core/list/tail.rs
@@ -7,7 +7,7 @@ use crate::value::{Object, RuntimeValue};
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 const DOCUMENTATION: &str = include_str!("tail.adoc");
@@ -49,7 +49,7 @@ impl Function for Tail {
 
                 Ok(Output::Transform(Arc::new(result.into())).into())
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/maven/gav.rs
+++ b/engine/src/core/maven/gav.rs
@@ -67,3 +67,36 @@ impl Function for GAV {
         })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::assert_satisfied;
+    use crate::runtime::testutil::test_common;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    pub async fn test_gav() {
+        let result = test_common(
+            r#"
+pattern test = maven::GAV
+"#,
+            "org.quarkus:quarkus:2.3",
+        )
+        .await;
+
+        assert_satisfied!(&result);
+        assert_eq!(
+            result.output(),
+            Arc::new(
+                json!({
+                    "groupId": "org.quarkus",
+                    "artifactId": "quarkus",
+                    "version":"2.3",
+                    "packaging": "jar",
+                })
+                .into()
+            )
+        )
+    }
+}

--- a/engine/src/core/maven/gav.rs
+++ b/engine/src/core/maven/gav.rs
@@ -6,7 +6,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 #[allow(clippy::upper_case_acronyms)]
@@ -59,10 +59,10 @@ impl Function for GAV {
 
                     Ok(Output::Transform(Arc::new(coordinates.into())).into())
                 } else {
-                    Ok(Output::None.into())
+                    Ok(Severity::Error.into())
                 }
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/mod.rs
+++ b/engine/src/core/mod.rs
@@ -1,7 +1,7 @@
 use crate::lang::lir::Bindings;
-use crate::runtime::rationale::Rationale;
 use crate::runtime::{
-    EvalContext, EvaluationResult, Output, Pattern, PatternName, RuntimeError, World,
+    rationale::Rationale, EvalContext, EvaluationResult, Output, Pattern, PatternName,
+    RuntimeError, World,
 };
 use crate::value::RuntimeValue;
 

--- a/engine/src/core/net/inet4addr.rs
+++ b/engine/src/core/net/inet4addr.rs
@@ -1,4 +1,4 @@
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use crate::runtime::EvalContext;
 use crate::{
     core::{Function, FunctionEvaluationResult},
@@ -47,17 +47,17 @@ impl Function for Inet4Addr {
                                         if range.contains(&addr) {
                                             Ok(Output::Identity.into())
                                         } else {
-                                            Ok(Output::None.into())
+                                            Ok(Severity::Error.into())
                                         }
                                     }
                                     Err(e) => {
                                         return Ok((
-                                            Output::None,
+                                            Severity::Error,
                                             vec![EvaluationResult::new(
                                                 input,
                                                 address_pattern,
                                                 Rationale::InvalidArgument(e.to_string()),
-                                                Output::None,
+                                                Output::Identity,
                                             )],
                                         )
                                             .into())
@@ -68,12 +68,12 @@ impl Function for Inet4Addr {
                         Err(e) => {
                             let e = format!("error parsing inet4addr<\"{range}\">: {e}");
                             return Ok((
-                                Output::None,
+                                Severity::Error,
                                 vec![EvaluationResult::new(
                                     input,
                                     address_pattern,
                                     Rationale::InvalidArgument(e),
-                                    Output::None,
+                                    Output::Identity,
                                 )],
                             )
                                 .into());
@@ -81,7 +81,7 @@ impl Function for Inet4Addr {
                     }
                 }
             }
-            Ok(Output::None.into())
+            Ok(Severity::Error.into())
         })
     }
 }

--- a/engine/src/core/openvex/csaf.rs
+++ b/engine/src/core/openvex/csaf.rs
@@ -209,6 +209,7 @@ fn flag2justification(flag: &FlagLabel) -> Justification {
 
 #[cfg(test)]
 mod tests {
+    use crate::assert_satisfied;
     use crate::runtime::testutil::test_pattern;
 
     #[tokio::test]
@@ -216,6 +217,6 @@ mod tests {
         let input = include_str!("../csaf/rhba-2023_0564.json");
         let json: serde_json::Value = serde_json::from_str(input).unwrap();
         let result = test_pattern(r#"openvex::from-csaf"#, json).await;
-        assert!(result.satisfied());
+        assert_satisfied!(result);
     }
 }

--- a/engine/src/core/openvex/csaf.rs
+++ b/engine/src/core/openvex/csaf.rs
@@ -10,7 +10,7 @@ use std::pin::Pin;
 
 use std::sync::Arc;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use csaf::{vulnerability::FlagLabel, *};
 use openvex::*;
 
@@ -48,7 +48,7 @@ impl Function for FromCsaf {
                             }
                             Err(e) => {
                                 log::warn!("Error looking up {:?}", e);
-                                return Ok(Output::None.into());
+                                return Ok(Severity::Error.into());
                             }
                         }
                     }
@@ -67,13 +67,13 @@ impl Function for FromCsaf {
                         Err(e) => {
                             log::warn!("Error looking up {:?}", e);
                             println!("Unable to parse: {:?}", e);
-                            Ok(Output::None.into())
+                            Ok(Severity::Error.into())
                         }
                     }
                 }
                 _v => {
                     let msg = "input is neither a Object nor a List";
-                    Ok((Output::None, Rationale::InvalidArgument(msg.into())).into())
+                    Ok((Severity::Error, Rationale::InvalidArgument(msg.into())).into())
                 }
             }
         })

--- a/engine/src/core/openvex/guac.rs
+++ b/engine/src/core/openvex/guac.rs
@@ -11,7 +11,7 @@ use guac_rs::client::vulns2vex;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -48,7 +48,7 @@ impl Function for FromGuac {
                             }
                             Err(e) => {
                                 log::warn!("Error looking up {:?}", e);
-                                return Ok(Output::None.into());
+                                return Ok(Severity::Error.into());
                             }
                         }
                     }
@@ -59,7 +59,7 @@ impl Function for FromGuac {
                 }
                 _v => {
                     let msg = "input is neither a Object nor a List";
-                    Ok((Output::None, Rationale::InvalidArgument(msg.into())).into())
+                    Ok((Severity::Error, Rationale::InvalidArgument(msg.into())).into())
                 }
             }
         })

--- a/engine/src/core/openvex/osv.rs
+++ b/engine/src/core/openvex/osv.rs
@@ -13,7 +13,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use super::super::osv::client::*;
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use openvex::*;
 
 #[derive(Debug)]
@@ -50,7 +50,7 @@ impl Function for FromOsv {
                             }
                             Err(e) => {
                                 log::warn!("Error looking up {:?}", e);
-                                return Ok(Output::None.into());
+                                return Ok(Severity::Error.into());
                             }
                         }
                     }
@@ -68,13 +68,13 @@ impl Function for FromOsv {
                         }
                         Err(e) => {
                             log::warn!("Error looking up {:?}", e);
-                            Ok(Output::None.into())
+                            Ok(Severity::Error.into())
                         }
                     }
                 }
                 _v => {
                     let msg = "input is neither a Object nor a List";
-                    Ok((Output::None, Rationale::InvalidArgument(msg.into())).into())
+                    Ok((Severity::Error, Rationale::InvalidArgument(msg.into())).into())
                 }
             }
         })

--- a/engine/src/core/osv/purl.rs
+++ b/engine/src/core/osv/purl.rs
@@ -8,7 +8,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 use super::client::*;
@@ -126,7 +126,7 @@ impl Function for ScanPurl {
         Box::pin(async move {
             match ScanPurl::from_purls(input.as_json()).await {
                 Ok(Some(json)) => Ok(Output::Transform(Arc::new(json.into())).into()),
-                _ => Ok(Output::None.into()),
+                _ => Ok(Severity::Error.into()),
             }
         })
     }

--- a/engine/src/core/pem/mod.rs
+++ b/engine/src/core/pem/mod.rs
@@ -11,6 +11,8 @@ use base64::Engine;
 use std::future::Future;
 use std::pin::Pin;
 
+use crate::lang::Severity;
+use crate::runtime::rationale::Rationale;
 use std::str::from_utf8;
 use std::sync::Arc;
 
@@ -37,7 +39,11 @@ impl Function for AsCertificate {
             let bytes = if let Some(inner) = input.try_get_octets() {
                 inner
             } else {
-                return Ok(Output::None.into());
+                return Ok((
+                    Severity::Error,
+                    Rationale::InvalidArgument("Requires octets as input".to_string()),
+                )
+                    .into());
             };
 
             let contents = PEM_ENGINE.encode(bytes);

--- a/engine/src/core/rhsa/find_advisory.rs
+++ b/engine/src/core/rhsa/find_advisory.rs
@@ -10,7 +10,7 @@ use csaf::Csaf;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -48,11 +48,11 @@ impl Function for FindAdvisory {
                             return Ok(Output::Transform(Arc::new(json.into())).into());
                         }
                     }
-                    Ok(Output::None.into())
+                    Ok(Severity::Error.into())
                 }
                 _v => {
                     let msg = "input is not a string";
-                    Ok((Output::None, Rationale::InvalidArgument(msg.into())).into())
+                    Ok((Severity::Error, Rationale::InvalidArgument(msg.into())).into())
                 }
             }
         })

--- a/engine/src/core/rhsa/from_cve.rs
+++ b/engine/src/core/rhsa/from_cve.rs
@@ -8,7 +8,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -45,12 +45,12 @@ impl Function for FromCve {
                             .collect();
                         Ok(Output::Transform(Arc::new(RuntimeValue::List(output))).into())
                     } else {
-                        Ok(Output::None.into())
+                        Ok(Severity::Error.into())
                     }
                 }
                 _v => {
                     let msg = "input is not a string";
-                    Ok((Output::None, Rationale::InvalidArgument(msg.into())).into())
+                    Ok((Severity::Error, Rationale::InvalidArgument(msg.into())).into())
                 }
             }
         })

--- a/engine/src/core/rhsa/mod.rs
+++ b/engine/src/core/rhsa/mod.rs
@@ -57,8 +57,8 @@ mod tests {
     fn can_parse_id() {
         assert!("RHSA-2022:1234".parse::<AdvisoryId>().is_ok());
         assert!("RHBA-2022:1234".parse::<AdvisoryId>().is_ok());
-        assert!(!"rhsa-2022:1234".parse::<AdvisoryId>().is_ok());
-        assert!(!"RHSA-2022::1234".parse::<AdvisoryId>().is_ok());
-        assert!(!"RHSA2022:1234".parse::<AdvisoryId>().is_ok());
+        assert!("rhsa-2022:1234".parse::<AdvisoryId>().is_err());
+        assert!("RHSA-2022::1234".parse::<AdvisoryId>().is_err());
+        assert!("RHSA2022:1234".parse::<AdvisoryId>().is_err());
     }
 }

--- a/engine/src/core/showcase/meta.dog
+++ b/engine/src/core/showcase/meta.dog
@@ -9,3 +9,18 @@ pattern deprecated_simple = {}
 /// This pattern is marked deprecated, with additional details.
 #[deprecated("This is so 2022!", since="2023")]
 pattern deprecated_details = {}
+
+/// A pattern making use of Asciidoc
+///
+/// Like *bold*, _italic_, or `monospace`.
+///
+/// NOTE: Also more complex constructs should be possible.
+///
+/// Like code blocks:
+///
+/// [source,json]
+/// ----
+/// { "foo": {"bar": true}} <1>
+/// ----
+/// <1> The usual "foo bar"
+pattern using_asciidoc = {}

--- a/engine/src/core/showcase/mod.rs
+++ b/engine/src/core/showcase/mod.rs
@@ -1,8 +1,8 @@
 use crate::core::{BlockingFunction, FunctionEvaluationResult};
 use crate::lang::lir::Bindings;
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use crate::package::Package;
-use crate::runtime::{EvalContext, Output, RuntimeError};
+use crate::runtime::{EvalContext, RuntimeError};
 use crate::runtime::{PackagePath, World};
 use crate::value::RuntimeValue;
 use std::sync::Arc;
@@ -14,6 +14,7 @@ pub fn package() -> Package {
     pkg
 }
 
+/// Example for a built-in function, adding metadata.
 #[derive(Debug)]
 pub struct BuiltIn;
 
@@ -35,6 +36,6 @@ impl BlockingFunction for BuiltIn {
         _world: &World,
     ) -> Result<FunctionEvaluationResult, RuntimeError> {
         // does nothing
-        Ok(Output::Identity.into())
+        Ok(Severity::None.into())
     }
 }

--- a/engine/src/core/sigstore/mod.rs
+++ b/engine/src/core/sigstore/mod.rs
@@ -14,7 +14,7 @@ use std::borrow::Borrow;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 mod verify;
@@ -83,10 +83,10 @@ impl Function for SHA256 {
 
                     Ok(Output::Transform(Arc::new(transform.into())).into())
                 } else {
-                    Ok(Output::None.into())
+                    Ok(Severity::Error.into())
                 }
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/sigstore/verify.rs
+++ b/engine/src/core/sigstore/verify.rs
@@ -112,7 +112,7 @@ mod test {
     use super::*;
     use crate::{assert_satisfied, runtime::testutil::test_patterns};
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn verify_blob() {
         let result = test_patterns(
             r#"
@@ -124,10 +124,10 @@ mod test {
             RuntimeValue::String("something\n".to_string()),
         )
         .await;
-        assert_satisfied!(result);
+        assert_satisfied!(&result);
 
-        let output = result.output().unwrap();
-        assert!(output.is_boolean());
-        assert!(output.try_get_boolean().unwrap());
+        let output = result.output();
+        assert_eq!(output.is_boolean(), true);
+        assert_eq!(output.try_get_boolean().unwrap(), true);
     }
 }

--- a/engine/src/core/sigstore/verify.rs
+++ b/engine/src/core/sigstore/verify.rs
@@ -1,6 +1,6 @@
 use crate::core::{Function, FunctionEvaluationResult};
 use crate::lang::lir::{Bindings, InnerPattern};
-use crate::lang::ValuePattern;
+use crate::lang::{Severity, ValuePattern};
 use crate::runtime::rationale::Rationale;
 
 use crate::lang::PatternMeta;
@@ -87,7 +87,7 @@ impl Function for VerifyBlob {
                     }
                 }
             }
-            Ok(Output::None.into())
+            Ok(Severity::Error.into())
         })
     }
 }
@@ -103,7 +103,7 @@ fn get_parameter(param: &str, bindings: &Bindings) -> Result<String, String> {
 }
 
 fn invalid_arg(msg: impl Into<String>) -> Result<FunctionEvaluationResult, RuntimeError> {
-    Ok((Output::None, Rationale::InvalidArgument(msg.into())).into())
+    Ok((Severity::Error, Rationale::InvalidArgument(msg.into())).into())
 }
 
 #[cfg(test)]

--- a/engine/src/core/spdx/compatible.rs
+++ b/engine/src/core/spdx/compatible.rs
@@ -77,9 +77,10 @@ mod test {
 
     use crate::runtime::testutil::test_pattern;
 
+    use crate::{assert_not_satisfied, assert_satisfied};
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn gpl() {
         let result = test_pattern(
             r#"
@@ -89,10 +90,10 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn fail() {
         let result = test_pattern(
             r#"
@@ -102,10 +103,10 @@ mod test {
         )
         .await;
 
-        assert!(!result.satisfied())
+        assert_not_satisfied!(result);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn multiple() {
         let result = test_pattern(
             r#"
@@ -115,10 +116,10 @@ mod test {
         )
         .await;
 
-        assert!(result.satisfied())
+        assert_satisfied!(result);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn multiple_fails() {
         let result = test_pattern(
             r#"
@@ -128,6 +129,6 @@ mod test {
         )
         .await;
 
-        assert!(!result.satisfied())
+        assert_not_satisfied!(result);
     }
 }

--- a/engine/src/core/spdx/compatible.rs
+++ b/engine/src/core/spdx/compatible.rs
@@ -4,7 +4,7 @@ use crate::runtime::{EvalContext, Output, RuntimeError, World};
 use crate::value::RuntimeValue;
 use spdx;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc; // as spdx_parser;
@@ -49,10 +49,10 @@ impl Function for Compatible {
                         })
                         .collect::<Vec<String>>(),
                     InnerPattern::Const(ValuePattern::String(license)) => vec![license.clone()],
-                    _ => return Ok(Output::None.into()),
+                    _ => return Ok(Severity::Error.into()),
                 }
             } else {
-                return Ok(Output::None.into());
+                return Ok(Severity::Error.into());
             };
 
             // the input should be a string
@@ -67,7 +67,7 @@ impl Function for Compatible {
                     }
                 }
             }
-            Ok(Output::None.into())
+            Ok(Severity::Error.into())
         })
     }
 }

--- a/engine/src/core/string/concat.rs
+++ b/engine/src/core/string/concat.rs
@@ -1,6 +1,6 @@
 use crate::core::{Function, FunctionEvaluationResult};
 use crate::lang::lir::Bindings;
-use crate::lang::ValuePattern;
+use crate::lang::{Severity, ValuePattern};
 use crate::runtime::{EvalContext, Output, RuntimeError, World};
 use crate::value::RuntimeValue;
 use std::future::Future;
@@ -48,10 +48,10 @@ impl Function for Concat {
                     };
                     Ok(Output::Transform(Arc::new(transformed.into())).into())
                 } else {
-                    Ok(Output::None.into())
+                    Ok(Severity::Error.into())
                 }
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/string/concat.rs
+++ b/engine/src/core/string/concat.rs
@@ -60,11 +60,12 @@ impl Function for Concat {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::assert_satisfied;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn can_append() {
         let src = Ephemeral::new(
             "test",
@@ -84,13 +85,13 @@ mod test {
             .await
             .unwrap();
 
-        assert!(result.satisfied());
-        let output = result.output().unwrap();
+        assert_satisfied!(&result);
+        let output = result.output();
         assert!(output.is_string());
         assert_eq!(output.as_json(), json!("data.json"));
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn can_prepend() {
         let src = Ephemeral::new(
             "test",
@@ -110,8 +111,8 @@ mod test {
             .await
             .unwrap();
 
-        assert!(result.satisfied());
-        let output = result.output().unwrap();
+        assert_satisfied!(&result);
+        let output = result.output();
         assert!(output.is_string());
         assert_eq!(output.as_json(), json!("my:data"));
     }

--- a/engine/src/core/string/contains.rs
+++ b/engine/src/core/string/contains.rs
@@ -51,11 +51,12 @@ impl Function for Contains {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::assert_satisfied;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn string_contains() {
         let src = Ephemeral::new(
             "test",
@@ -73,18 +74,13 @@ mod test {
                 json!("Some people like coffee."),
                 EvalContext::default(),
             )
-            .await;
-        assert!(result.as_ref().unwrap().satisfied());
-        assert!(result
-            .as_ref()
-            .unwrap()
-            .output()
-            .unwrap()
-            .try_get_boolean()
-            .unwrap());
+            .await
+            .unwrap();
+        assert_satisfied!(&result);
+        assert_eq!(result.output().try_get_boolean().unwrap(), true);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn string_contains_no_substring() {
         let src = Ephemeral::new(
             "test",
@@ -102,14 +98,9 @@ mod test {
                 json!("anything old text here..."),
                 EvalContext::default(),
             )
-            .await;
-        assert!(result.as_ref().unwrap().satisfied());
-        assert!(!result
-            .as_ref()
-            .unwrap()
-            .output()
-            .unwrap()
-            .try_get_boolean()
-            .unwrap());
+            .await
+            .unwrap();
+        assert_satisfied!(&result);
+        assert_eq!(result.output().try_get_boolean().unwrap(), false);
     }
 }

--- a/engine/src/core/string/contains.rs
+++ b/engine/src/core/string/contains.rs
@@ -75,16 +75,13 @@ mod test {
             )
             .await;
         assert!(result.as_ref().unwrap().satisfied());
-        assert_eq!(
-            result
-                .as_ref()
-                .unwrap()
-                .output()
-                .unwrap()
-                .try_get_boolean()
-                .unwrap(),
-            true
-        );
+        assert!(result
+            .as_ref()
+            .unwrap()
+            .output()
+            .unwrap()
+            .try_get_boolean()
+            .unwrap());
     }
 
     #[actix_rt::test]
@@ -107,15 +104,12 @@ mod test {
             )
             .await;
         assert!(result.as_ref().unwrap().satisfied());
-        assert_eq!(
-            result
-                .as_ref()
-                .unwrap()
-                .output()
-                .unwrap()
-                .try_get_boolean()
-                .unwrap(),
-            false
-        );
+        assert!(!result
+            .as_ref()
+            .unwrap()
+            .output()
+            .unwrap()
+            .try_get_boolean()
+            .unwrap());
     }
 }

--- a/engine/src/core/string/length.rs
+++ b/engine/src/core/string/length.rs
@@ -5,7 +5,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 const DOCUMENTATION: &str = include_str!("length.adoc");
@@ -32,7 +32,7 @@ impl Function for Length {
             if let Some(value) = input.try_get_string() {
                 Ok(Output::Transform(Arc::new(value.len().into())).into())
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/string/length.rs
+++ b/engine/src/core/string/length.rs
@@ -43,9 +43,10 @@ mod test {
     use super::*;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
+    use crate::{assert_not_satisfied, assert_satisfied};
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_length() {
         let src = Ephemeral::new(
             "test",
@@ -64,11 +65,10 @@ mod test {
             .evaluate("test::ten", json!("abcdefghij"), EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_alias() {
         let src = Ephemeral::new(
             "test",
@@ -87,10 +87,10 @@ mod test {
             .evaluate("test::ten", json!("abcdefghij"), EvalContext::default())
             .await;
 
-        assert!(result.unwrap().satisfied())
+        assert_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_non_matching_length() {
         let src = Ephemeral::new(
             "test",
@@ -113,13 +113,10 @@ mod test {
             )
             .await;
 
-        println!("result --> {result:?}");
-
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_non_matching_not_a_string() {
         let src = Ephemeral::new(
             "test",
@@ -138,7 +135,6 @@ mod test {
             .evaluate("test::ten", json!(10), EvalContext::default())
             .await;
 
-        //assert!(matches!(result, Ok(RationaleResult::Same(_)),))
-        assert!(!result.unwrap().satisfied())
+        assert_not_satisfied!(result.unwrap());
     }
 }

--- a/engine/src/core/string/regexp.rs
+++ b/engine/src/core/string/regexp.rs
@@ -60,9 +60,10 @@ mod test {
     use super::*;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
+    use crate::{assert_not_satisfied, assert_satisfied};
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_matching_with_valid_param() {
         let src = Ephemeral::new(
             "test",
@@ -84,10 +85,11 @@ mod test {
                 EvalContext::default(),
             )
             .await;
-        assert!(result.unwrap().satisfied())
+
+        assert_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nonmatching_with_valid_param() {
         let src = Ephemeral::new(
             "test",
@@ -109,10 +111,11 @@ mod test {
                 EvalContext::default(),
             )
             .await;
-        assert!(!result.unwrap().satisfied());
+
+        assert_not_satisfied!(result.unwrap());
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn call_nonmatching_with_invalid_param() {
         let src = Ephemeral::new(
             "test",
@@ -134,6 +137,7 @@ mod test {
                 EvalContext::default(),
             )
             .await;
-        assert!(!result.unwrap().satisfied());
+
+        assert_not_satisfied!(result.unwrap());
     }
 }

--- a/engine/src/core/string/regexp.rs
+++ b/engine/src/core/string/regexp.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 const DOCUMENTATION: &str = include_str!("regexp.adoc");
@@ -50,7 +50,7 @@ impl Function for Regexp {
                     }
                 }
             }
-            Ok(Output::None.into())
+            Ok(Severity::Error.into())
         })
     }
 }

--- a/engine/src/core/string/split.rs
+++ b/engine/src/core/string/split.rs
@@ -53,11 +53,12 @@ impl Function for Split {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::assert_satisfied;
     use crate::lang::builder::Builder;
     use crate::runtime::sources::Ephemeral;
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn string_split() {
         let src = Ephemeral::new(
             "test",
@@ -71,10 +72,11 @@ mod test {
         let runtime = builder.finish().await.unwrap();
         let result = runtime
             .evaluate("test::sp", json!("1,2,3,4"), EvalContext::default())
-            .await;
-        assert!(result.as_ref().unwrap().satisfied());
+            .await
+            .unwrap();
+        assert_satisfied!(&result);
 
-        let output = result.unwrap().output().unwrap();
+        let output = result.output();
         let list = output.try_get_list().unwrap();
         assert_eq!(list.len(), 4);
         assert!(list.contains(&Arc::new(RuntimeValue::String("1".to_string()))));
@@ -83,7 +85,7 @@ mod test {
         assert!(list.contains(&Arc::new(RuntimeValue::String("4".to_string()))));
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn string_split_no_pattern() {
         let src = Ephemeral::new(
             "test",
@@ -97,15 +99,16 @@ mod test {
         let runtime = builder.finish().await.unwrap();
         let result = runtime
             .evaluate("test::sp", json!("1,2,3,4"), EvalContext::default())
-            .await;
-        assert!(result.as_ref().unwrap().satisfied());
+            .await
+            .unwrap();
+        assert_satisfied!(&result);
 
-        let output = result.unwrap().output().unwrap();
+        let output = result.output();
         let list = output.try_get_list().unwrap();
         assert_eq!(list.len(), 0);
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn string_split_no_pattern_found() {
         let src = Ephemeral::new(
             "test",
@@ -119,10 +122,11 @@ mod test {
         let runtime = builder.finish().await.unwrap();
         let result = runtime
             .evaluate("test::sp", json!("1:2:3:4"), EvalContext::default())
-            .await;
-        assert!(result.as_ref().unwrap().satisfied());
+            .await
+            .unwrap();
+        assert_satisfied!(&result);
 
-        let output = result.unwrap().output().unwrap();
+        let output = result.output();
         let list = output.try_get_list().unwrap();
         assert_eq!(list.len(), 1);
         assert!(list.contains(&Arc::new(RuntimeValue::String("1:2:3:4".to_string()))));

--- a/engine/src/core/timestamp/rfc2822.rs
+++ b/engine/src/core/timestamp/rfc2822.rs
@@ -5,7 +5,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 const DOCUMENTATION: &str = include_str!("rfc2822.adoc");
@@ -32,10 +32,10 @@ impl Function for Rfc2822 {
             if let Some(value) = input.try_get_string() {
                 match ::chrono::DateTime::parse_from_rfc2822(&value) {
                     Ok(_) => Ok(Output::Identity.into()),
-                    Err(_) => Ok(Output::None.into()),
+                    Err(_) => Ok(Severity::Error.into()),
                 }
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/timestamp/rfc3339.rs
+++ b/engine/src/core/timestamp/rfc3339.rs
@@ -5,7 +5,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 const DOCUMENTATION: &str = include_str!("rfc3339.adoc");
@@ -32,10 +32,10 @@ impl Function for Rfc3339 {
             if let Some(value) = input.try_get_string() {
                 match ::chrono::DateTime::parse_from_rfc3339(&value) {
                     Ok(_) => Ok(Output::Identity.into()),
-                    Err(_) => Ok(Output::None.into()),
+                    Err(_) => Ok(Severity::Error.into()),
                 }
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/uri/iri.rs
+++ b/engine/src/core/uri/iri.rs
@@ -5,7 +5,7 @@ use crate::value::RuntimeValue;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use std::sync::Arc;
 
 const DOCUMENTATION: &str = include_str!("iri.adoc");
@@ -32,10 +32,10 @@ impl Function for Iri {
             if let Some(value) = input.try_get_string() {
                 match ::iref::Iri::new(&value) {
                     Ok(_) => Ok(Output::Identity.into()),
-                    Err(_) => Ok(Output::None.into()),
+                    Err(_) => Ok(Severity::Error.into()),
                 }
             } else {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             }
         })
     }

--- a/engine/src/core/uri/purl.rs
+++ b/engine/src/core/uri/purl.rs
@@ -132,6 +132,7 @@ impl Purl {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::assert_satisfied;
     use crate::runtime::testutil::test_pattern;
     use serde_json::json;
 
@@ -145,7 +146,7 @@ mod test {
 
         assert_eq!(
             result.output(),
-            Some(Arc::new(
+            Arc::new(
                 json!({
                     "type": "rpm",
                     "namespace": "fedora",
@@ -157,7 +158,7 @@ mod test {
                     },
                 })
                 .into()
-            ))
+            )
         );
     }
 
@@ -171,7 +172,7 @@ mod test {
 
         assert_eq!(
             result.output(),
-            Some(Arc::new(
+            Arc::new(
                 json!({
                     "type": "docker",
                     "namespace": "customer",
@@ -182,7 +183,7 @@ mod test {
                     },
                 })
                 .into()
-            ))
+            )
         );
     }
 
@@ -192,14 +193,14 @@ mod test {
 
         assert_eq!(
             result.output(),
-            Some(Arc::new(
+            Arc::new(
                 json!({
                     "type": "cargo",
                     "name": "rand",
                     "version": "0.7.2",
                 })
                 .into()
-            ))
+            )
         );
     }
 
@@ -213,7 +214,7 @@ mod test {
 
         assert_eq!(
             result.output(),
-            Some(Arc::new(
+            Arc::new(
                 json!({
                     "type": "github",
                     "namespace": "package-url",
@@ -222,7 +223,7 @@ mod test {
                     "subpath": "everybody/loves/dogs",
                 })
                 .into()
-            ))
+            )
         );
     }
 
@@ -241,13 +242,11 @@ mod test {
         )
         .await;
 
-        eprintln!("Rationale: {:#?}", result.rationale());
-
-        assert!(result.satisfied());
+        assert_satisfied!(&result);
 
         assert_eq!(
             result.output(),
-            Some(Arc::new(
+            Arc::new(
                 json!({
                     "type": "rpm",
                     "namespace": "fedora",
@@ -259,7 +258,7 @@ mod test {
                     },
                 })
                 .into()
-            ))
+            )
         );
     }
 
@@ -269,13 +268,13 @@ mod test {
 
         assert_eq!(
             result.output(),
-            Some(Arc::new(
+            Arc::new(
                 json!({
                     "type": "pypi",
                     "name": "django",
                 })
                 .into()
-            ))
+            )
         );
     }
 }

--- a/engine/src/core/uri/purl.rs
+++ b/engine/src/core/uri/purl.rs
@@ -1,7 +1,7 @@
 use crate::core::uri::url::Url;
 use crate::core::{BlockingFunction, Example, FunctionEvaluationResult};
 use crate::lang::lir::Bindings;
-use crate::lang::PatternMeta;
+use crate::lang::{PatternMeta, Severity};
 use crate::runtime::rationale::Rationale;
 use crate::runtime::{EvalContext, Output, RuntimeError, World};
 use crate::value::{Object, RuntimeValue};
@@ -125,7 +125,7 @@ impl Purl {
     }
 
     fn invalid_arg(msg: impl Into<String>) -> Result<FunctionEvaluationResult, RuntimeError> {
-        Ok((Output::None, Rationale::InvalidArgument(msg.into())).into())
+        Ok((Severity::Error, Rationale::InvalidArgument(msg.into())).into())
     }
 }
 

--- a/engine/src/core/uri/url.rs
+++ b/engine/src/core/uri/url.rs
@@ -1,11 +1,8 @@
 use crate::core::{BlockingFunction, FunctionEvaluationResult};
-use crate::lang::lir::Bindings;
-use crate::runtime::rationale::Rationale;
-use crate::runtime::{EvalContext, Output, RuntimeError, World};
+use crate::lang::{lir::Bindings, PatternMeta, Severity};
+use crate::runtime::{rationale::Rationale, EvalContext, Output, RuntimeError, World};
 use crate::value::{Object, RuntimeValue};
 use std::fmt::Debug;
-
-use crate::lang::PatternMeta;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -34,7 +31,7 @@ impl BlockingFunction for Url {
                 Err(result) => Ok(result),
             },
             _ => Ok((
-                Output::None,
+                Severity::Error,
                 Rationale::InvalidArgument("input is not a String".into()),
             )
                 .into()),
@@ -60,7 +57,7 @@ impl Url {
                 Ok(result)
             }
             Err(err) => Err((
-                Output::None,
+                Severity::Error,
                 Rationale::InvalidArgument(format!("input is not a URL: {err}")),
             )
                 .into()),

--- a/engine/src/core/x509/mod.rs
+++ b/engine/src/core/x509/mod.rs
@@ -1,13 +1,10 @@
 use crate::core::{Function, FunctionEvaluationResult};
-use crate::lang::lir::Bindings;
+use crate::lang::{lir::Bindings, Severity};
 use crate::package::Package;
-use crate::runtime::{EvalContext, Output, RuntimeError};
-use crate::runtime::{PackagePath, World};
+use crate::runtime::{EvalContext, Output, PackagePath, RuntimeError, World};
 use crate::value::RuntimeValue;
-
 use std::future::Future;
 use std::pin::Pin;
-
 use std::sync::Arc;
 use x509_parser::parse_x509_certificate;
 use x509_parser::pem::Pem;
@@ -43,7 +40,7 @@ impl Function for PEM {
             } else if let Some(inner) = input.try_get_octets() {
                 bytes.extend_from_slice(inner);
             } else {
-                return Ok(Output::None.into());
+                return Ok(Severity::Error.into());
             };
 
             let mut certs: Vec<RuntimeValue> = Vec::new();
@@ -58,7 +55,7 @@ impl Function for PEM {
             }
 
             if certs.is_empty() {
-                Ok(Output::None.into())
+                Ok(Severity::Error.into())
             } else {
                 Ok(Output::Transform(Arc::new(certs.into())).into())
             }
@@ -86,12 +83,12 @@ impl Function for DER {
             let bytes = if let Some(inner) = input.try_get_octets() {
                 inner
             } else {
-                return Ok(Output::None.into());
+                return Ok(Severity::Error.into());
             };
 
             match parse_x509_certificate(bytes) {
                 Ok((_, cert)) => Ok(Output::Transform(Arc::new((&cert).into())).into()),
-                Err(_) => Ok(Output::None.into()),
+                Err(_) => Ok(Severity::Error.into()),
             }
         })
     }

--- a/engine/src/lang/builder.rs
+++ b/engine/src/lang/builder.rs
@@ -73,9 +73,10 @@ mod test {
     use crate::runtime::sources::Ephemeral;
     use crate::runtime::EvalContext;
 
+    use crate::assert_satisfied;
     use serde_json::json;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn basic_smoke_test() {
         let src = Ephemeral::new(
             "foo::bar",
@@ -109,6 +110,6 @@ mod test {
             )
             .await;
 
-        assert!(result.unwrap().satisfied());
+        assert_satisfied!(result.unwrap());
     }
 }

--- a/engine/src/lang/lir/mod.rs
+++ b/engine/src/lang/lir/mod.rs
@@ -395,6 +395,8 @@ impl Pattern {
                 if let Some(obj) = locked_value.try_get_object() {
                     let mut result = HashMap::new();
 
+                    // TODO: think about pre-aggregating the severity to later on just use the result
+
                     for field in &inner.fields {
                         if let Some(ref field_value) = obj.get(field.name()) {
                             result.insert(

--- a/engine/src/lang/meta.rs
+++ b/engine/src/lang/meta.rs
@@ -1,6 +1,7 @@
+use crate::runtime::EvaluationResult;
 use crate::{
     lang::hir,
-    runtime::{metadata::Documentation, BuildError},
+    runtime::{is_default, metadata::Documentation, BuildError},
 };
 use serde::{Deserialize, Serialize};
 
@@ -11,8 +12,8 @@ pub struct PatternMeta {
     pub unstable: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deprecation: Option<Deprecation>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<String>,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub reporting: Reporting,
 }
 
 impl PatternMeta {
@@ -27,13 +28,10 @@ impl TryFrom<hir::Metadata> for PatternMeta {
 
     fn try_from(mut value: hir::Metadata) -> Result<Self, Self::Error> {
         Ok(Self {
+            reporting: (&value).into(),
             documentation: Documentation(value.documentation),
             unstable: value.attributes.contains_key("unstable"),
             deprecation: value.attributes.remove("deprecated").map(Into::into),
-            explanation: value
-                .attributes
-                .remove("explain")
-                .and_then(|a| a.into_flags().next()),
         })
     }
 }
@@ -53,6 +51,89 @@ impl From<hir::AttributeValues> for Deprecation {
     }
 }
 
+/// Severity of the outcome
+///
+/// | Value     | Satisfied |
+/// | --------- | :-------: |
+/// | `None`    | ✅        |
+/// | `Advice`  | ✅        |
+/// | `Warning` | ✅        |
+/// | `Error`   | ❌        |
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Severity {
+    /// Good
+    #[default]
+    None,
+    /// All good, but there is something you might want to know
+    Advice,
+    /// Good, but smells fishy
+    Warning,
+    /// Boom! Bad!
+    Error,
+}
+
+impl FromIterator<Severity> for Severity {
+    fn from_iter<T: IntoIterator<Item = Severity>>(iter: T) -> Self {
+        let mut highest = Severity::None;
+
+        for s in iter {
+            if s == Severity::Error {
+                return Severity::Error;
+            }
+            if s > highest {
+                highest = s;
+            }
+        }
+
+        highest
+    }
+}
+
+impl<'a> FromIterator<&'a EvaluationResult> for Severity {
+    fn from_iter<T: IntoIterator<Item = &'a EvaluationResult>>(iter: T) -> Self {
+        iter.into_iter().map(|e| e.severity()).collect()
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Reporting {
+    /// Override severity
+    ///
+    /// Everything other than [`Severity::None`] will override a non [`Severity::None`] value with
+    /// the severity with this value.
+    pub severity: Severity,
+    /// In case of a non [`Severity::None`] value, this can be used to override the "reason".
+    pub explanation: Option<String>,
+}
+
+impl From<&hir::Metadata> for Reporting {
+    fn from(value: &hir::Metadata) -> Self {
+        // try "explain", then "warning", then "advice"
+        value
+            .attributes
+            .get("explain")
+            .map(|attr| (Severity::Error, attr))
+            .or_else(|| {
+                value
+                    .attributes
+                    .get("warning")
+                    .map(|attr| (Severity::Warning, attr))
+            })
+            .or_else(|| {
+                value
+                    .attributes
+                    .get("advice")
+                    .map(|attr| (Severity::Advice, attr))
+            })
+            .map(|(severity, attr)| Reporting {
+                severity,
+                explanation: attr.flags().next().map(ToString::to_string),
+            })
+            .unwrap_or_default()
+    }
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PackageMeta {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -68,5 +149,32 @@ impl PackageMeta {
             }
             None => self.documentation = Some(docs.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::lang::Severity;
+
+    #[test]
+    fn test_highest() {
+        let s: Severity = vec![Severity::Warning, Severity::Warning, Severity::Advice]
+            .into_iter()
+            .collect();
+        assert_eq!(Severity::Warning, s);
+    }
+
+    #[test]
+    fn test_empty() {
+        let s: Severity = vec![].into_iter().collect();
+        assert_eq!(Severity::None, s);
+    }
+
+    #[test]
+    fn test_err() {
+        let s: Severity = vec![Severity::Warning, Severity::Error, Severity::Advice]
+            .into_iter()
+            .collect();
+        assert_eq!(Severity::None, s);
     }
 }

--- a/engine/src/lang/mir/mod.rs
+++ b/engine/src/lang/mir/mod.rs
@@ -618,8 +618,7 @@ impl Lowerer {
                 if let Some(child) = parent_pkg
                     .packages
                     .iter_mut()
-                    .filter(|s| s.name == child_name.0)
-                    .next()
+                    .find(|s| s.name == child_name.0)
                 {
                     child.apply_meta(meta);
                 }

--- a/engine/src/lang/parser/meta.rs
+++ b/engine/src/lang/parser/meta.rs
@@ -181,8 +181,8 @@ mod test {
         assert_eq!(
             attr,
             Located::new(
-                AttributeDefn::new(Located::new("attr".to_string(), 0..0usize.into()), vec![]),
-                0..0usize.into()
+                AttributeDefn::new(Located::new("attr".to_string(), 0..0usize), vec![]),
+                0..0usize
             )
         );
     }
@@ -192,10 +192,7 @@ mod test {
         let attr = attribute_definition().parse(r#"#[attr()]"#).unwrap();
         assert_eq!(
             attr,
-            Located::new(
-                AttributeDefn::new(located("attr"), vec![]),
-                0..0usize.into()
-            )
+            Located::new(AttributeDefn::new(located("attr"), vec![]), 0..0usize)
         );
     }
 
@@ -206,7 +203,7 @@ mod test {
             attr,
             Located::new(
                 AttributeDefn::new(located("attr"), vec![AttributeValue::Flag(located("foo"))]),
-                0..0usize.into()
+                0..0usize
             )
         );
     }
@@ -226,7 +223,7 @@ mod test {
                         AttributeValue::Flag(located("bar"))
                     ]
                 ),
-                0..0usize.into()
+                0..0usize
             )
         );
     }
@@ -246,7 +243,7 @@ mod test {
                         AttributeValue::Flag(located("bar"))
                     ]
                 ),
-                0..0usize.into()
+                0..0usize
             )
         );
     }
@@ -266,7 +263,7 @@ mod test {
                         value: located("true")
                     },]
                 ),
-                0..0usize.into()
+                0..0usize
             )
         );
     }
@@ -289,7 +286,7 @@ mod test {
                         AttributeValue::Flag(located("flag"))
                     ]
                 ),
-                0..0usize.into()
+                0..0usize
             )
         );
     }
@@ -306,7 +303,7 @@ mod test {
                     located("attr"),
                     vec![AttributeValue::Flag(located("foo bar")),]
                 ),
-                0..0usize.into()
+                0..0usize
             )
         );
     }
@@ -333,7 +330,7 @@ mod test {
                         },
                     ]
                 ),
-                0..0usize.into()
+                0..0usize
             )
         );
     }

--- a/engine/src/lang/parser/ty.rs
+++ b/engine/src/lang/parser/ty.rs
@@ -95,7 +95,7 @@ pub fn doc_comment_line() -> impl Parser<ParserInput, String, Error = ParserErro
     common_comment_line(just("///"))
 }
 
-fn common_comment_line<'a>(
+fn common_comment_line(
     start: impl Parser<ParserInput, &'static str, Error = ParserError> + Clone,
 ) -> impl Parser<ParserInput, String, Error = ParserError> + Clone {
     start.then(take_until(text::newline())).padded().map(|v| {

--- a/engine/src/runtime/metadata.rs
+++ b/engine/src/runtime/metadata.rs
@@ -19,7 +19,7 @@ pub struct Documentation(pub Option<String>);
 impl Display for Documentation {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Some(docs) = &self.0 {
-            f.write_str(&docs)?;
+            f.write_str(docs)?;
         }
         Ok(())
     }
@@ -60,7 +60,7 @@ impl DerefMut for Documentation {
 impl Documentation {
     pub fn split(&self) -> (&str, &str) {
         match &self.0 {
-            Some(docs) => docs.split_once("\n\n").unwrap_or((&docs, "")),
+            Some(docs) => docs.split_once("\n\n").unwrap_or((docs, "")),
             None => ("", ""),
         }
     }

--- a/engine/src/runtime/mod.rs
+++ b/engine/src/runtime/mod.rs
@@ -921,6 +921,25 @@ pub mod testutil {
             );
         }};
     }
+
+    /// Run a common test.
+    ///
+    /// The name of the pattern which will be required is "test".
+    pub async fn test_common(
+        content: impl Into<String>,
+        value: impl Into<RuntimeValue>,
+    ) -> EvaluationResult {
+        let src = Ephemeral::new("test", content);
+
+        let mut builder = Builder::new();
+        builder.build(src.iter()).unwrap();
+        let runtime = builder.finish().await.unwrap();
+
+        runtime
+            .evaluate("test::test", value, EvalContext::default())
+            .await
+            .unwrap()
+    }
 }
 
 #[cfg(test)]

--- a/engine/src/runtime/mod.rs
+++ b/engine/src/runtime/mod.rs
@@ -165,6 +165,7 @@ impl EvaluationResult {
         }
     }
 
+    /// Get both the severity and the reason.
     pub fn outcome(&self) -> (Severity, String) {
         // the evaluated severity
         let mut severity = self.rationale.severity();
@@ -189,12 +190,21 @@ impl EvaluationResult {
         (severity, reason)
     }
 
+    /// Get the severity only.
     pub fn severity(&self) -> Severity {
-        self.outcome().0
-    }
+        // the evaluated severity
+        let mut severity = self.rationale.severity();
 
-    pub fn reason(&self) -> String {
-        self.outcome().1
+        if severity > Severity::None {
+            // a possible override severity
+            let override_severity = self.ty.metadata().reporting.severity;
+
+            if override_severity > Severity::None {
+                severity = override_severity;
+            }
+        }
+
+        severity
     }
 
     pub fn ty(&self) -> Arc<Pattern> {

--- a/engine/src/runtime/mod.rs
+++ b/engine/src/runtime/mod.rs
@@ -825,7 +825,7 @@ pub mod testutil {
     {
         init_logger();
         let mut builder = Builder::new();
-        builder.data(DirectoryDataSource::new(test_data_dir().into()));
+        builder.data(DirectoryDataSource::new(test_data_dir()));
         builder.build(src.iter()).unwrap();
         let runtime = builder.finish().await.unwrap();
         let result = runtime
@@ -850,7 +850,7 @@ pub mod testutil {
             assert!(
                 $result.satisfied(),
                 "{}",
-                serde_json::to_string_pretty(&crate::runtime::response::Response::new(&$result))
+                serde_json::to_string_pretty(&$crate::runtime::response::Response::new(&$result))
                     .unwrap()
             );
         };
@@ -862,7 +862,7 @@ pub mod testutil {
             assert!(
                 !$result.satisfied(),
                 "{}",
-                serde_json::to_string_pretty(&crate::runtime::response::Response::new(&$result))
+                serde_json::to_string_pretty(&$crate::runtime::response::Response::new(&$result))
                     .unwrap()
             );
         };

--- a/engine/src/runtime/monitor/dispatcher.rs
+++ b/engine/src/runtime/monitor/dispatcher.rs
@@ -1,5 +1,6 @@
 //! Sharing monitoring results in memory between modules.
 use crate::lang::lir::Pattern;
+use crate::lang::Severity;
 use crate::runtime::monitor::{CompleteEvent, Completion, MonitorEvent, StartEvent};
 use crate::runtime::{Output, RuntimeError};
 use crate::value::RuntimeValue;
@@ -58,6 +59,7 @@ impl Monitor {
         &self,
         correlation: u64,
         ty: Arc<Pattern>,
+        severity: Severity,
         output: Output,
         elapsed: Option<Duration>,
     ) {
@@ -65,7 +67,7 @@ impl Monitor {
             correlation,
             timestamp: Utc::now(),
             ty,
-            completion: Completion::Output(output),
+            completion: Completion::Ok { severity, output },
             elapsed,
         };
         self.fanout(event.into()).await;

--- a/engine/src/runtime/rationale.rs
+++ b/engine/src/runtime/rationale.rs
@@ -24,7 +24,6 @@ pub enum Rationale {
         rationale: Option<Box<Rationale>>,
         supporting: Vec<EvaluationResult>,
     },
-    Refinement(Box<EvaluationResult>, Option<Box<EvaluationResult>>),
     Bound(Box<Rationale>, Bindings),
 }
 
@@ -54,17 +53,6 @@ impl Rationale {
                 supporting: _,
             } => *severity,
             Rationale::Chain(terms) => terms.iter().collect(),
-            // TODO: check if this is still used
-            Rationale::Refinement(primary, refinement) => {
-                if matches!(primary.severity(), Severity::Error) {
-                    Severity::Error
-                } else if let Some(refinement) = refinement {
-                    refinement.severity()
-                } else {
-                    // TODO: check if this is really error, maybe it should be "ok"?
-                    Severity::Error
-                }
-            }
             Rationale::Bound(inner, _) => inner.severity(),
         }
     }
@@ -130,7 +118,6 @@ impl Rationale {
                 }
                 .to_string(),
             },
-            Rationale::Refinement(_, _) => String::new(),
             Rationale::Bound(inner, _) => inner.reason(),
         }
     }

--- a/engine/src/runtime/rationale.rs
+++ b/engine/src/runtime/rationale.rs
@@ -1,4 +1,7 @@
-use crate::{lang::lir::Bindings, runtime::EvaluationResult};
+use crate::{
+    lang::{lir::Bindings, Severity},
+    runtime::EvaluationResult,
+};
 use std::collections::HashMap;
 
 /// Rationale for a policy decision.
@@ -16,39 +19,119 @@ pub enum Rationale {
     Const(bool),
     Primordial(bool),
     Expression(bool),
-    Function(bool, Option<Box<Rationale>>, Vec<EvaluationResult>),
+    Function {
+        severity: Severity,
+        rationale: Option<Box<Rationale>>,
+        supporting: Vec<EvaluationResult>,
+    },
     Refinement(Box<EvaluationResult>, Option<Box<EvaluationResult>>),
     Bound(Box<Rationale>, Bindings),
 }
 
 impl Rationale {
-    pub fn satisfied(&self) -> bool {
+    pub fn severity(&self) -> Severity {
         match self {
-            Rationale::Anything => true,
-            Rationale::Nothing => false,
+            Rationale::Anything => Severity::None,
+            Rationale::Nothing => Severity::Error,
             Rationale::Object(fields) => fields
                 .values()
-                .all(|e| e.as_ref().map(|e| e.satisfied()).unwrap_or(false)),
-            Rationale::List(items) => items.iter().all(|e| e.satisfied()),
-            Rationale::NotAnObject => false,
-            Rationale::NotAList => false,
-            Rationale::MissingField(_) => false,
-            Rationale::InvalidArgument(_) => false,
-            Rationale::Const(val) => *val,
-            Rationale::Primordial(val) => *val,
-            Rationale::Expression(val) => *val,
-            Rationale::Function(val, _rational, _) => *val,
-            Rationale::Chain(terms) => terms.iter().all(|e| e.satisfied()),
-            Rationale::Refinement(primary, refinement) => {
-                if !primary.satisfied() {
-                    false
-                } else if let Some(refinement) = refinement {
-                    refinement.satisfied()
-                } else {
-                    false
+                .filter_map(|r| r.as_ref().map(|r| r.severity()))
+                .collect(),
+            Rationale::List(items) => items.iter().collect(),
+            Rationale::NotAnObject => Severity::Error,
+            Rationale::NotAList => Severity::Error,
+            Rationale::MissingField(_) => Severity::Error,
+            Rationale::InvalidArgument(_) => Severity::Error,
+            Rationale::Const(val) | Rationale::Primordial(val) | Rationale::Expression(val) => {
+                match *val {
+                    true => Severity::None,
+                    false => Severity::Error,
                 }
             }
-            Rationale::Bound(inner, _) => inner.satisfied(),
+            Rationale::Function {
+                severity,
+                rationale: _,
+                supporting: _,
+            } => *severity,
+            Rationale::Chain(terms) => terms.iter().collect(),
+            // TODO: check if this is still used
+            Rationale::Refinement(primary, refinement) => {
+                if matches!(primary.severity(), Severity::Error) {
+                    Severity::Error
+                } else if let Some(refinement) = refinement {
+                    refinement.severity()
+                } else {
+                    // TODO: check if this is really error, maybe it should be "ok"?
+                    Severity::Error
+                }
+            }
+            Rationale::Bound(inner, _) => inner.severity(),
+        }
+    }
+
+    pub fn reason(&self) -> String {
+        match self {
+            Rationale::Anything => "anything is satisfied by anything".into(),
+            Rationale::Nothing => "Nothing".into(),
+            Rationale::Const(_) => {
+                if self.severity() < Severity::Error {
+                    "The input matches the expected constant value expected in the pattern"
+                } else {
+                    "The input does not match the constant value expected in the pattern"
+                }
+            }
+            .into(),
+            Rationale::Primordial(_) => {
+                if self.severity() < Severity::Error {
+                    "The primordial type defined in the pattern is satisfied"
+                } else {
+                    "The primordial type defined in the pattern is not satisfied"
+                }
+            }
+            .into(),
+            Rationale::Expression(_) => if self.severity() < Severity::Error {
+                "The expression defined in the pattern is satisfied"
+            } else {
+                "The expression defined in the pattern is not satisfied"
+            }
+            .into(),
+            Rationale::Object(_) => if self.severity() < Severity::Error {
+                "Because all fields were satisfied"
+            } else {
+                "Because not all fields were satisfied"
+            }
+            .into(),
+            Rationale::List(_terms) => if self.severity() < Severity::Error {
+                "because all members were satisfied"
+            } else {
+                "because not all members were satisfied"
+            }
+            .into(),
+            Rationale::Chain(_terms) => if self.severity() < Severity::Error {
+                "because the chain was satisfied"
+            } else {
+                "because the chain was not satisfied"
+            }
+            .into(),
+            Rationale::NotAnObject => "not an object".into(),
+            Rationale::NotAList => "not a list".into(),
+            Rationale::MissingField(name) => format!("missing field: {name}"),
+            Rationale::InvalidArgument(name) => format!("invalid argument: {name}"),
+            Rationale::Function {
+                severity: _,
+                rationale,
+                supporting: _,
+            } => match rationale {
+                Some(x) => x.reason(),
+                None => if self.severity() < Severity::Error {
+                    "The input satisfies the function"
+                } else {
+                    "The input does not satisfy the function"
+                }
+                .to_string(),
+            },
+            Rationale::Refinement(_, _) => String::new(),
+            Rationale::Bound(inner, _) => inner.reason(),
         }
     }
 }

--- a/engine/src/runtime/rationale.rs
+++ b/engine/src/runtime/rationale.rs
@@ -35,7 +35,7 @@ impl Rationale {
             Rationale::Nothing => Severity::Error,
             Rationale::Object(fields) => fields
                 .values()
-                .filter_map(|r| r.as_ref().map(|r| r.severity()))
+                .map(|r| r.as_ref().map(|e| e.severity()).unwrap_or(Severity::Error))
                 .collect(),
             Rationale::List(items) => items.iter().collect(),
             Rationale::NotAnObject => Severity::Error,

--- a/engine/src/runtime/response.rs
+++ b/engine/src/runtime/response.rs
@@ -112,7 +112,7 @@ impl Serialize for Response {
             .map(String::from)
             .collect::<Vec<_>>()
         };
-        let count = fields.iter().map(|s| check(s)).count();
+        let count = fields.iter().filter(|s| check(s)).count();
         let mut state = serializer.serialize_struct("Response", count)?;
         for name in &fields {
             if check(name) {

--- a/engine/src/runtime/response.rs
+++ b/engine/src/runtime/response.rs
@@ -125,7 +125,7 @@ impl Serialize for Response {
 
 impl Response {
     pub fn new(result: &EvaluationResult) -> Self {
-        let severity = result.severity();
+        let (severity, reason) = result.outcome();
         let output = match &result.output {
             Output::Identity if !matches!(severity, Severity::Error) => {
                 Some(result.input.as_json())
@@ -143,7 +143,7 @@ impl Response {
             input: result.input().as_json(),
             output,
             severity,
-            reason: result.reason(),
+            reason,
             rationale: support(rationale),
             bindings: bound(bindings),
             fields: Vec::new(),

--- a/engine/src/runtime/response.rs
+++ b/engine/src/runtime/response.rs
@@ -301,10 +301,6 @@ fn support(rationale: &Rationale) -> Vec<Response> {
         | Rationale::Function {
             supporting: terms, ..
         } => terms.iter().map(Response::new).collect(),
-        Rationale::Refinement(primary, refinement) => match refinement {
-            Some(r) => vec![Response::new(primary), Response::new(r)],
-            None => vec![Response::new(primary)],
-        },
         Rationale::Bound(inner, _) => support(inner),
         Rationale::Anything
         | Rationale::Nothing

--- a/engine/src/runtime/response.rs
+++ b/engine/src/runtime/response.rs
@@ -279,8 +279,10 @@ fn support(rationale: &Rationale) -> Vec<Response> {
                         let v = Response::new(er);
                         if v.rationale.is_empty() {
                             let mut x = v.clone();
+                            let (severity, reason) = er.outcome();
                             x.name = Name::Field(n.to_string());
-                            x.reason = er.reason();
+                            x.severity = severity;
+                            x.reason = reason;
                             x.rationale = vec![v];
                             x
                         } else {

--- a/engine/src/runtime/response.rs
+++ b/engine/src/runtime/response.rs
@@ -91,7 +91,7 @@ impl Serialize for Response {
             "rationale" => state.serialize_field("rationale", &self.rationale),
             _ => Err(ser::Error::custom(format!("Unknown field name: {s}"))),
         };
-        let fields = if self.fields.len() > 0 {
+        let fields = if !self.fields.is_empty() {
             self.fields.clone()
         } else {
             [
@@ -326,7 +326,6 @@ pub(crate) fn default_reason(r#type: &Pattern, rationale: &Rationale) -> String 
         Rationale::Refinement(_, _) => String::new(),
         Rationale::Bound(inner, _) => reason(r#type, inner),
     }
-    .into()
 }
 
 fn support(rationale: &Rationale) -> Vec<Response> {

--- a/engine/src/runtime/response.rs
+++ b/engine/src/runtime/response.rs
@@ -158,7 +158,7 @@ impl Response {
     pub fn collapse(mut self, severity: Severity) -> Self {
         let mut rationale = vec![];
 
-        self.walk_tree(severity, |response| {
+        self.walk_tree(|response| {
             if response.satisfied(severity) {
                 return false;
             }
@@ -182,22 +182,22 @@ impl Response {
     ///
     /// The callback can return `true` if it want to keep descending into the children of
     /// the current response, or `false` otherwise.
-    pub fn walk_tree<'a, F>(&'a self, min_severity: Severity, mut f: F)
+    pub fn walk_tree<'a, F>(&'a self, mut f: F)
     where
         F: FnMut(&'a Response) -> bool,
     {
-        self.walk_tree_internal(min_severity, &mut f);
+        self.walk_tree_internal(&mut f);
     }
 
     /// An internal version of `walk_tree`, which takes a reference to the callback, so
     /// that it can be called recursively.
-    fn walk_tree_internal<'a, F>(&'a self, min_severity: Severity, f: &mut F)
+    fn walk_tree_internal<'a, F>(&'a self, f: &mut F)
     where
         F: FnMut(&'a Response) -> bool,
     {
-        if f(&self) {
+        if f(self) {
             for x in &self.rationale {
-                x.walk_tree_internal(min_severity, f);
+                x.walk_tree_internal(f);
             }
         }
     }

--- a/engine/src/runtime/response.rs
+++ b/engine/src/runtime/response.rs
@@ -112,7 +112,7 @@ impl Serialize for Response {
             .map(String::from)
             .collect::<Vec<_>>()
         };
-        let count = fields.iter().map(|s| check(s) as usize).sum();
+        let count = fields.iter().map(|s| check(s)).count();
         let mut state = serializer.serialize_struct("Response", count)?;
         for name in &fields {
             if check(name) {
@@ -159,7 +159,7 @@ impl Response {
         self
     }
 
-    // Expects a comma-delimited list, e.g. "name,bindings,input,output,satisfied,reason,rationale"
+    // Expects a comma-delimited list, e.g. "name,bindings,input,output,severity,reason,rationale"
     pub fn filter(&mut self, fields: &str) -> &mut Self {
         let fields = fields.trim().to_lowercase();
         if !fields.is_empty() {
@@ -262,7 +262,7 @@ fn deeply_unsatisfied(severity: Severity, tree: Vec<Response>) -> Vec<Response> 
                 // input if no children do. If wrong, we must recur.
                 result.push(i);
             } else {
-                result.append(&mut deeply_unsatisfied(severity, i.rationale.clone()));
+                result.append(&mut deeply_unsatisfied(severity, i.rationale));
             }
         }
     }

--- a/engine/src/runtime/statistics/monitor.rs
+++ b/engine/src/runtime/statistics/monitor.rs
@@ -1,12 +1,13 @@
 use crate::runtime::monitor::Completion;
 use crate::runtime::statistics::Snapshot;
-use crate::runtime::{Output, PatternName};
+use crate::runtime::PatternName;
 use num_integer::Roots;
 
 use rand::Rng;
 
 use std::collections::HashMap;
 
+use crate::lang::Severity;
 use std::time::Duration;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
@@ -135,8 +136,11 @@ impl<const N: usize> PatternStats<N> {
     fn record(&mut self, elapsed: Duration, completion: &Completion) {
         self.invocations += 1;
         match completion {
-            Completion::Output(output) => match output {
-                Output::None => self.unsatisfied_invocations += 1,
+            Completion::Ok {
+                severity,
+                output: _,
+            } => match severity {
+                Severity::Error => self.unsatisfied_invocations += 1,
                 _ => self.satisfied_invocations += 1,
             },
             Completion::Err(_) => {

--- a/engine/src/runtime/statistics/prometheus.rs
+++ b/engine/src/runtime/statistics/prometheus.rs
@@ -1,6 +1,7 @@
 use crate::runtime::monitor::Completion;
-use crate::runtime::{Output, PatternName};
+use crate::runtime::PatternName;
 
+use crate::lang::Severity;
 use std::time::Duration;
 
 #[cfg(feature = "prometheus")]
@@ -53,8 +54,11 @@ impl PrometheusStats {
         completion: &Completion,
     ) {
         match completion {
-            Completion::Output(output) => match output {
-                Output::None => self.unsatisfied.with_label_values(&[name.name()]).inc(),
+            Completion::Ok {
+                severity,
+                output: _,
+            } => match severity {
+                Severity::Error => self.unsatisfied.with_label_values(&[name.name()]).inc(),
                 _ => self.satisfied.with_label_values(&[name.name()]).inc(),
             },
             Completion::Err(_) => self.error.with_label_values(&[name.name()]).inc(),

--- a/engine/src/runtime/utils.rs
+++ b/engine/src/runtime/utils.rs
@@ -1,0 +1,3 @@
+pub fn is_default<T: Default + PartialEq>(value: &T) -> bool {
+    value == &T::default()
+}

--- a/engine/src/value/mod.rs
+++ b/engine/src/value/mod.rs
@@ -180,6 +180,12 @@ impl From<&[u8]> for RuntimeValue {
     }
 }
 
+impl<const N: usize> From<&[u8; N]> for RuntimeValue {
+    fn from(inner: &[u8; N]) -> Self {
+        inner.to_vec().into()
+    }
+}
+
 impl From<Vec<RuntimeValue>> for RuntimeValue {
     fn from(inner: Vec<RuntimeValue>) -> Self {
         Self::List(inner.into_iter().map(Arc::new).collect())

--- a/engine/src/value/mod.rs
+++ b/engine/src/value/mod.rs
@@ -501,13 +501,14 @@ here:
         assert_eq!(
             RuntimeValue::Object({
                 let mut o = Object::new();
-                o.set("bar", {
-                    let mut s = Vec::new();
-                    s.push(Arc::new(1i64.into()));
-                    s.push(Arc::new("baz".into()));
-                    s.push(Arc::new(true.into()));
-                    s
-                });
+                o.set(
+                    "bar",
+                    vec![
+                        Arc::new(1i64.into()),
+                        Arc::new("baz".into()),
+                        Arc::new(true.into()),
+                    ],
+                );
                 o.set("foo", "bar");
                 o.set("here", {
                     let mut o = Object::new();

--- a/engine/tests/common.rs
+++ b/engine/tests/common.rs
@@ -1,3 +1,6 @@
+// Some tests don't use all functions, that might trigger warnings
+#![allow(unused)]
+
 use seedwing_policy_engine::{
     lang::{builder::Builder, Severity},
     runtime::{

--- a/engine/tests/common.rs
+++ b/engine/tests/common.rs
@@ -1,6 +1,9 @@
 use seedwing_policy_engine::{
-    lang::builder::Builder,
-    runtime::{response::Name, sources::Ephemeral, EvalContext, EvaluationResult, Response, World},
+    lang::{builder::Builder, Severity},
+    runtime::{
+        is_default, response::Name, sources::Ephemeral, EvalContext, EvaluationResult, Response,
+        World,
+    },
 };
 use serde_json::Value;
 use std::fmt::{Debug, Display};
@@ -9,8 +12,10 @@ use std::fmt::{Debug, Display};
 pub struct Reason {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub failed: Option<String>,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub severity: Severity,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub reason: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rationale: Vec<Reason>,
 }
@@ -31,10 +36,8 @@ impl From<Response> for Reason {
                 Name::Pattern(Some(pattern)) => pattern.to_string(),
                 Name::Pattern(None) => String::new(),
             },
-            failed: match value.satisfied {
-                true => None,
-                false => Some(value.reason),
-            },
+            severity: value.severity,
+            reason: value.reason,
             rationale: value
                 .rationale
                 .into_iter()

--- a/engine/tests/explain.rs
+++ b/engine/tests/explain.rs
@@ -14,7 +14,8 @@ pattern test = {}
         json!(false),
         json!({
             "name": "test::test",
-            "failed": "Not foo",
+            "severity": "error",
+            "reason": "Not foo",
         }),
     )
     .await;
@@ -34,13 +35,16 @@ pattern test = {
         json!({"bar": "bar"}),
         json!({
             "name": "test::test",
+            "severity": "error",
             "failed": "Because not all fields were satisfied",
             "rationale": [
                 {
                     "name": "field:bar",
-                    "failed": "Not baz",
+                    "severity": "error",
+                    "reason": "Not baz",
                     "rationale": [{
-                        "failed": "Not baz"
+                        "severity": "error",
+                        "reason": "Not baz"
                     }]
                 }
             ]
@@ -68,13 +72,16 @@ pattern test = {
         }),
         json!({
             "name": "test::test",
+            "severity": "error",
             "failed": "Because not all fields were satisfied",
             "rationale": [
                 {
                     "name": "field:bar",
-                    "failed": "Not baz",
+                    "severity": "error",
+                    "reason": "Not baz",
                     "rationale": [{
-                        "failed": "Not baz",
+                        "severity": "error",
+                        "reason": "Not baz",
                     }]
                 },
                 {
@@ -104,6 +111,7 @@ pattern test = {
         }),
         json!({
             "name": "test::test",
+            "severity": "error",
             "failed": "Because not all fields were satisfied",
             "rationale": [
             ]

--- a/engine/tests/explain.rs
+++ b/engine/tests/explain.rs
@@ -36,7 +36,7 @@ pattern test = {
         json!({
             "name": "test::test",
             "severity": "error",
-            "failed": "Because not all fields were satisfied",
+            "reason": "Because not all fields were satisfied",
             "rationale": [
                 {
                     "name": "field:bar",
@@ -73,7 +73,7 @@ pattern test = {
         json!({
             "name": "test::test",
             "severity": "error",
-            "failed": "Because not all fields were satisfied",
+            "reason": "Because not all fields were satisfied",
             "rationale": [
                 {
                     "name": "field:bar",
@@ -86,9 +86,10 @@ pattern test = {
                 },
                 {
                     "name": "field:foo",
-                    "rationale": [
-                        {}
-                    ]
+                    "reason": "The input matches the expected constant value expected in the pattern",
+                    "rationale": [{
+                        "reason": "The input matches the expected constant value expected in the pattern",
+                    }]
                 },
             ]
         }),
@@ -112,7 +113,7 @@ pattern test = {
         json!({
             "name": "test::test",
             "severity": "error",
-            "failed": "Because not all fields were satisfied",
+            "reason": "Because not all fields were satisfied",
             "rationale": [
             ]
         }),

--- a/engine/tests/levels.rs
+++ b/engine/tests/levels.rs
@@ -26,7 +26,7 @@ pattern test = {
         json!({
             "name": "test::test",
             "severity": "error",
-            "reason": "because not all fields were satisfied",
+            "reason": "Because not all fields were satisfied",
             "rationale": [
                 {
                     "name": "field:advice",
@@ -85,7 +85,7 @@ pattern test = {
         json!({
             "name": "test::test",
             "severity": "advice",
-            "reason": "because not all fields were satisfied",
+            "reason": "Because all fields were satisfied",
             "rationale": [
                 {
                     "name": "field:advice",
@@ -98,11 +98,17 @@ pattern test = {
                 },
                 {
                     "name": "field:error",
-                    "rationale": [{}]
+                    "reason": "The input matches the expected constant value expected in the pattern",
+                    "rationale": [{
+                        "reason": "The input matches the expected constant value expected in the pattern"
+                    }]
                 },
                 {
                     "name": "field:warning",
-                    "rationale": [{}]
+                    "reason": "The input matches the expected constant value expected in the pattern",
+                    "rationale": [{
+                        "reason": "The input matches the expected constant value expected in the pattern"
+                    }]
                 },
             ]
         }),

--- a/engine/tests/levels.rs
+++ b/engine/tests/levels.rs
@@ -1,0 +1,113 @@
+use serde_json::json;
+
+mod common;
+
+use common::*;
+
+#[tokio::test]
+async fn levels_examples() -> anyhow::Result<()> {
+    assert_eval(
+        r#"
+pattern test = {
+    #[advice("advice")]
+    advice: false,
+    #[warning("warning")]
+    warning: false,
+    // defaults to #[error]
+    #[explain("error")]
+    error: false,
+}
+"#,
+        json!({
+            "advice": true,
+            "warning": true,
+            "error": true,
+        }),
+        json!({
+            "name": "test::test",
+            "severity": "error",
+            "reason": "because not all fields were satisfied",
+            "rationale": [
+                {
+                    "name": "field:advice",
+                    "severity": "advice",
+                    "reason": "advice",
+                    "rationale": [{
+                        "severity": "advice",
+                        "reason": "advice",
+                    }]
+                },
+                {
+                    "name": "field:error",
+                    "severity": "error",
+                    "reason": "error",
+                    "rationale": [{
+                        "severity": "error",
+                        "reason": "error",
+                    }]
+                },
+                {
+                    "name": "field:warning",
+                    "severity": "warning",
+                    "reason": "warning",
+                    "rationale": [{
+                        "severity": "warning",
+                        "reason": "warning",
+                    }]
+                },
+            ]
+        }),
+    )
+    .await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn levels_default_to_highest() -> anyhow::Result<()> {
+    assert_eval(
+        r#"
+pattern test = {
+    #[advice("advice")]
+    advice: false,
+    #[warning("warning")]
+    warning: false,
+    // defaults to #[error]
+    #[explain("error")]
+    error: false,
+}
+"#,
+        json!({
+            "advice": true,
+            "warning": false,
+            "error": false,
+        }),
+        json!({
+            "name": "test::test",
+            "severity": "advice",
+            "reason": "because not all fields were satisfied",
+            "rationale": [
+                {
+                    "name": "field:advice",
+                    "severity": "advice",
+                    "reason": "advice",
+                    "rationale": [{
+                        "severity": "advice",
+                        "reason": "advice",
+                    }]
+                },
+                {
+                    "name": "field:error",
+                    "rationale": [{}]
+                },
+                {
+                    "name": "field:warning",
+                    "rationale": [{}]
+                },
+            ]
+        }),
+    )
+    .await;
+
+    Ok(())
+}

--- a/engine/tests/proxy.dog
+++ b/engine/tests/proxy.dog
@@ -1,0 +1,39 @@
+
+pattern context = not-affected
+
+pattern not-affected = {
+  purl: uri::purl | osv::scan-purl | openvex::from-osv | openvex::not-affected
+}
+
+
+
+pattern foo = minimum && require-invalid-sig
+
+pattern minimum = {
+  url: string,
+  hash: string
+}
+
+pattern require-invalid-sig = {
+    hash: sigstore::sha256(
+        list::any<{
+            apiVersion: "0.0.1",
+            spec: {
+                signature: {
+                    publicKey: {
+                        content: base64::base64(
+                            x509::pem( list::any<{
+                                version: 2,
+                                extensions: list::any<{
+                                    subjectAlternativeName: list::any<{
+                                        rfc822: "invalid@invalid.org",
+                                    }>
+                                }>
+                            }> )
+                        )
+                    }
+                }
+            }
+        }>
+    )
+}

--- a/engine/tests/proxy.rs
+++ b/engine/tests/proxy.rs
@@ -1,0 +1,23 @@
+use seedwing_policy_engine::lang::Severity;
+use seedwing_policy_engine::runtime::Response;
+use serde_json::json;
+
+mod common;
+
+#[tokio::test]
+async fn test_jdom() {
+    let input = json!({
+      "hash": "02bd61a725e8af9b0176b43bf29816d0c748b8ab951385bd127be37489325a0a",
+      "purl": "pkg:maven/org.jdom/jdom@1.1.3?type=jar&repository_url=https%3A%2F%2Frepo.maven.apache.org%2Fmaven2",
+      "url": "https://repo.maven.apache.org/maven2/org/jdom/jdom/1.1.3/jdom-1.1.3.jar"
+    });
+
+    let result = common::eval(include_str!("proxy.dog"), "not-affected", input).await;
+    assert_eq!(result.severity(), Severity::Error);
+
+    let response = Response::new(&result);
+    println!("{}", serde_json::to_string_pretty(&response).unwrap());
+
+    let response = response.collapse(Severity::Error);
+    println!("{}", serde_json::to_string_pretty(&response).unwrap());
+}

--- a/engine/tests/proxy.rs
+++ b/engine/tests/proxy.rs
@@ -4,7 +4,12 @@ use serde_json::json;
 
 mod common;
 
+/// Test the proxy case with the jdom example
+///
+/// NOTE: This test is ignored by default as it is an online test which might fail and
+/// return different data in the future.
 #[tokio::test]
+#[ignore]
 async fn test_jdom() {
     let input = json!({
       "hash": "02bd61a725e8af9b0176b43bf29816d0c748b8ab951385bd127be37489325a0a",

--- a/engine/tests/response-data/proxy-jdom.json
+++ b/engine/tests/response-data/proxy-jdom.json
@@ -1,0 +1,960 @@
+{
+  "name": {
+    "pattern": "test::not-affected"
+  },
+  "input": {
+    "hash": "02bd61a725e8af9b0176b43bf29816d0c748b8ab951385bd127be37489325a0a",
+    "purl": "pkg:maven/org.jdom/jdom@1.1.3?type=jar&repository_url=https%3A%2F%2Frepo.maven.apache.org%2Fmaven2",
+    "url": "https://repo.maven.apache.org/maven2/org/jdom/jdom/1.1.3/jdom-1.1.3.jar"
+  },
+  "severity": "error",
+  "reason": "Because not all fields were satisfied",
+  "rationale": [
+    {
+      "bindings": {
+        "terms": []
+      },
+      "input": "pkg:maven/org.jdom/jdom@1.1.3?type=jar&repository_url=https%3A%2F%2Frepo.maven.apache.org%2Fmaven2",
+      "severity": "error",
+      "reason": "The input does not satisfy the function",
+      "rationale": [
+        {
+          "name": {
+            "pattern": "uri::purl"
+          },
+          "bindings": {
+            "terms": []
+          },
+          "input": "pkg:maven/org.jdom/jdom@1.1.3?type=jar&repository_url=https%3A%2F%2Frepo.maven.apache.org%2Fmaven2",
+          "output": {
+            "name": "jdom",
+            "namespace": "org.jdom",
+            "qualifiers": {
+              "repository_url": "https://repo.maven.apache.org/maven2",
+              "type": "jar"
+            },
+            "type": "maven",
+            "version": "1.1.3"
+          },
+          "severity": "none",
+          "reason": "The input satisfies the function"
+        },
+        {
+          "name": {
+            "pattern": "lang::refine"
+          },
+          "bindings": {
+            "terms": [],
+            "refinement": [
+              "lang::chain",
+              {
+                "terms": []
+              }
+            ]
+          },
+          "input": {
+            "name": "jdom",
+            "namespace": "org.jdom",
+            "qualifiers": {
+              "repository_url": "https://repo.maven.apache.org/maven2",
+              "type": "jar"
+            },
+            "type": "maven",
+            "version": "1.1.3"
+          },
+          "severity": "error",
+          "reason": "The input does not satisfy the function",
+          "rationale": [
+            {
+              "name": {
+                "pattern": "lang::chain"
+              },
+              "input": {
+                "name": "jdom",
+                "namespace": "org.jdom",
+                "qualifiers": {
+                  "repository_url": "https://repo.maven.apache.org/maven2",
+                  "type": "jar"
+                },
+                "type": "maven",
+                "version": "1.1.3"
+              },
+              "severity": "error",
+              "reason": "The input does not satisfy the function",
+              "rationale": [
+                {
+                  "name": {
+                    "pattern": "osv::scan-purl"
+                  },
+                  "bindings": {
+                    "terms": []
+                  },
+                  "input": {
+                    "name": "jdom",
+                    "namespace": "org.jdom",
+                    "qualifiers": {
+                      "repository_url": "https://repo.maven.apache.org/maven2",
+                      "type": "jar"
+                    },
+                    "type": "maven",
+                    "version": "1.1.3"
+                  },
+                  "output": {
+                    "vulns": [
+                      {
+                        "affected": [
+                          {
+                            "database_specific": {
+                              "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2021/07/GHSA-2363-cqg2-863c/GHSA-2363-cqg2-863c.json"
+                            },
+                            "package": {
+                              "ecosystem": "Maven",
+                              "name": "org.jdom:jdom",
+                              "purl": "pkg:maven/org.jdom/jdom"
+                            },
+                            "ranges": [
+                              {
+                                "events": [
+                                  {
+                                    "introduced": "0"
+                                  },
+                                  {}
+                                ],
+                                "type": "ECOSYSTEM"
+                              }
+                            ],
+                            "versions": [
+                              "1.1",
+                              "1.1.2",
+                              "1.1.3",
+                              "2.0.0",
+                              "2.0.1",
+                              "2.0.2"
+                            ]
+                          }
+                        ],
+                        "aliases": [
+                          "CVE-2021-33813"
+                        ],
+                        "database_specific": {
+                          "cwe_ids": [
+                            "CWE-611"
+                          ],
+                          "github_reviewed": true,
+                          "github_reviewed_at": "2021-07-27T19:02:41Z",
+                          "nvd_published_at": "2021-06-16T12:15:00Z",
+                          "severity": "HIGH"
+                        },
+                        "details": "An XXE issue in SAXBuilder in JDOM through 2.0.6 allows attackers to cause a denial of service via a crafted HTTP request.  At this time there is not released fixed version of JDOM.  As a workaround, to avoid external entities being expanded, one can call `builder.setExpandEntities(false)` and they won't be expanded.",
+                        "id": "GHSA-2363-cqg2-863c",
+                        "modified": "2023-03-28T05:39:14.823719Z",
+                        "published": "2021-07-27T19:02:56Z",
+                        "references": [
+                          {
+                            "type": "ADVISORY",
+                            "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-33813"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://github.com/hunterhacker/jdom/pull/188"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://github.com/hunterhacker/jdom/commit/dd4f3c2fc7893edd914954c73eb577f925a7d361"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://alephsecurity.com/vulns/aleph-2021003"
+                          },
+                          {
+                            "type": "PACKAGE",
+                            "url": "https://github.com/hunterhacker/jdom"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://github.com/hunterhacker/jdom/releases"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/r21c406c7ed88fe340db7dbae75e58355159e6c324037c7d5547bf40b@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/r5674106135bb1a6ef57483f4c63a9c44bca85d0e2a8a05895a8f1d89@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/r6db397ae7281ead825338200d1f62d2827585a70797cc9ac0c4bd23f@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/r845e987b7cd8efe610284958e997b84583f5a98d3394adc09e3482fe@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/r89b3800cfabb1e773e49425e5d4239c28a659839a2eca6af3431482e@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/r9974f64723875052e02787b2a5eda689ac5247c71b827d455e5dc9a6@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/rbc075a4ac85e7a8e47420b7383f16ffa0af3b792b8423584735f369f@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/rfb7a93e40ebeb1e0068cde0bf3834dcab46bb1ef06d6424db48ed9fd@%3Cdev.tika.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.debian.org/debian-lts-announce/2021/06/msg00026.html"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.debian.org/debian-lts-announce/2021/07/msg00012.html"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/AH46QHE5GIMT6BL6C3GDTOYF27JYILXM/"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EWFVYTHGILOQXUA7U3SPOERQXL7OPSZG/"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://www.oracle.com/security-alerts/cpuapr2022.html"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://www.oracle.com/security-alerts/cpujul2022.html"
+                          }
+                        ],
+                        "schema_version": "1.4.0",
+                        "severity": [
+                          {
+                            "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                            "type": "CVSS_V3"
+                          }
+                        ],
+                        "summary": "XML External Entity (XXE) Injection in JDOM"
+                      }
+                    ]
+                  },
+                  "severity": "none",
+                  "reason": "The input satisfies the function"
+                },
+                {
+                  "name": {
+                    "pattern": "lang::refine"
+                  },
+                  "bindings": {
+                    "refinement": [
+                      "lang::chain",
+                      {
+                        "terms": []
+                      }
+                    ],
+                    "terms": []
+                  },
+                  "input": {
+                    "vulns": [
+                      {
+                        "affected": [
+                          {
+                            "database_specific": {
+                              "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2021/07/GHSA-2363-cqg2-863c/GHSA-2363-cqg2-863c.json"
+                            },
+                            "package": {
+                              "ecosystem": "Maven",
+                              "name": "org.jdom:jdom",
+                              "purl": "pkg:maven/org.jdom/jdom"
+                            },
+                            "ranges": [
+                              {
+                                "events": [
+                                  {
+                                    "introduced": "0"
+                                  },
+                                  {}
+                                ],
+                                "type": "ECOSYSTEM"
+                              }
+                            ],
+                            "versions": [
+                              "1.1",
+                              "1.1.2",
+                              "1.1.3",
+                              "2.0.0",
+                              "2.0.1",
+                              "2.0.2"
+                            ]
+                          }
+                        ],
+                        "aliases": [
+                          "CVE-2021-33813"
+                        ],
+                        "database_specific": {
+                          "cwe_ids": [
+                            "CWE-611"
+                          ],
+                          "github_reviewed": true,
+                          "github_reviewed_at": "2021-07-27T19:02:41Z",
+                          "nvd_published_at": "2021-06-16T12:15:00Z",
+                          "severity": "HIGH"
+                        },
+                        "details": "An XXE issue in SAXBuilder in JDOM through 2.0.6 allows attackers to cause a denial of service via a crafted HTTP request.  At this time there is not released fixed version of JDOM.  As a workaround, to avoid external entities being expanded, one can call `builder.setExpandEntities(false)` and they won't be expanded.",
+                        "id": "GHSA-2363-cqg2-863c",
+                        "modified": "2023-03-28T05:39:14.823719Z",
+                        "published": "2021-07-27T19:02:56Z",
+                        "references": [
+                          {
+                            "type": "ADVISORY",
+                            "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-33813"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://github.com/hunterhacker/jdom/pull/188"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://github.com/hunterhacker/jdom/commit/dd4f3c2fc7893edd914954c73eb577f925a7d361"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://alephsecurity.com/vulns/aleph-2021003"
+                          },
+                          {
+                            "type": "PACKAGE",
+                            "url": "https://github.com/hunterhacker/jdom"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://github.com/hunterhacker/jdom/releases"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/r21c406c7ed88fe340db7dbae75e58355159e6c324037c7d5547bf40b@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/r5674106135bb1a6ef57483f4c63a9c44bca85d0e2a8a05895a8f1d89@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/r6db397ae7281ead825338200d1f62d2827585a70797cc9ac0c4bd23f@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/r845e987b7cd8efe610284958e997b84583f5a98d3394adc09e3482fe@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/r89b3800cfabb1e773e49425e5d4239c28a659839a2eca6af3431482e@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/r9974f64723875052e02787b2a5eda689ac5247c71b827d455e5dc9a6@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/rbc075a4ac85e7a8e47420b7383f16ffa0af3b792b8423584735f369f@%3Cissues.solr.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.apache.org/thread.html/rfb7a93e40ebeb1e0068cde0bf3834dcab46bb1ef06d6424db48ed9fd@%3Cdev.tika.apache.org%3E"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.debian.org/debian-lts-announce/2021/06/msg00026.html"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.debian.org/debian-lts-announce/2021/07/msg00012.html"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/AH46QHE5GIMT6BL6C3GDTOYF27JYILXM/"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EWFVYTHGILOQXUA7U3SPOERQXL7OPSZG/"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://www.oracle.com/security-alerts/cpuapr2022.html"
+                          },
+                          {
+                            "type": "WEB",
+                            "url": "https://www.oracle.com/security-alerts/cpujul2022.html"
+                          }
+                        ],
+                        "schema_version": "1.4.0",
+                        "severity": [
+                          {
+                            "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                            "type": "CVSS_V3"
+                          }
+                        ],
+                        "summary": "XML External Entity (XXE) Injection in JDOM"
+                      }
+                    ]
+                  },
+                  "severity": "error",
+                  "reason": "The input does not satisfy the function",
+                  "rationale": [
+                    {
+                      "name": {
+                        "pattern": "lang::chain"
+                      },
+                      "input": {
+                        "vulns": [
+                          {
+                            "affected": [
+                              {
+                                "database_specific": {
+                                  "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2021/07/GHSA-2363-cqg2-863c/GHSA-2363-cqg2-863c.json"
+                                },
+                                "package": {
+                                  "ecosystem": "Maven",
+                                  "name": "org.jdom:jdom",
+                                  "purl": "pkg:maven/org.jdom/jdom"
+                                },
+                                "ranges": [
+                                  {
+                                    "events": [
+                                      {
+                                        "introduced": "0"
+                                      },
+                                      {}
+                                    ],
+                                    "type": "ECOSYSTEM"
+                                  }
+                                ],
+                                "versions": [
+                                  "1.1",
+                                  "1.1.2",
+                                  "1.1.3",
+                                  "2.0.0",
+                                  "2.0.1",
+                                  "2.0.2"
+                                ]
+                              }
+                            ],
+                            "aliases": [
+                              "CVE-2021-33813"
+                            ],
+                            "database_specific": {
+                              "cwe_ids": [
+                                "CWE-611"
+                              ],
+                              "github_reviewed": true,
+                              "github_reviewed_at": "2021-07-27T19:02:41Z",
+                              "nvd_published_at": "2021-06-16T12:15:00Z",
+                              "severity": "HIGH"
+                            },
+                            "details": "An XXE issue in SAXBuilder in JDOM through 2.0.6 allows attackers to cause a denial of service via a crafted HTTP request.  At this time there is not released fixed version of JDOM.  As a workaround, to avoid external entities being expanded, one can call `builder.setExpandEntities(false)` and they won't be expanded.",
+                            "id": "GHSA-2363-cqg2-863c",
+                            "modified": "2023-03-28T05:39:14.823719Z",
+                            "published": "2021-07-27T19:02:56Z",
+                            "references": [
+                              {
+                                "type": "ADVISORY",
+                                "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-33813"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://github.com/hunterhacker/jdom/pull/188"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://github.com/hunterhacker/jdom/commit/dd4f3c2fc7893edd914954c73eb577f925a7d361"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://alephsecurity.com/vulns/aleph-2021003"
+                              },
+                              {
+                                "type": "PACKAGE",
+                                "url": "https://github.com/hunterhacker/jdom"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://github.com/hunterhacker/jdom/releases"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://lists.apache.org/thread.html/r21c406c7ed88fe340db7dbae75e58355159e6c324037c7d5547bf40b@%3Cissues.solr.apache.org%3E"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://lists.apache.org/thread.html/r5674106135bb1a6ef57483f4c63a9c44bca85d0e2a8a05895a8f1d89@%3Cissues.solr.apache.org%3E"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://lists.apache.org/thread.html/r6db397ae7281ead825338200d1f62d2827585a70797cc9ac0c4bd23f@%3Cissues.solr.apache.org%3E"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://lists.apache.org/thread.html/r845e987b7cd8efe610284958e997b84583f5a98d3394adc09e3482fe@%3Cissues.solr.apache.org%3E"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://lists.apache.org/thread.html/r89b3800cfabb1e773e49425e5d4239c28a659839a2eca6af3431482e@%3Cissues.solr.apache.org%3E"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://lists.apache.org/thread.html/r9974f64723875052e02787b2a5eda689ac5247c71b827d455e5dc9a6@%3Cissues.solr.apache.org%3E"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://lists.apache.org/thread.html/rbc075a4ac85e7a8e47420b7383f16ffa0af3b792b8423584735f369f@%3Cissues.solr.apache.org%3E"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://lists.apache.org/thread.html/rfb7a93e40ebeb1e0068cde0bf3834dcab46bb1ef06d6424db48ed9fd@%3Cdev.tika.apache.org%3E"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://lists.debian.org/debian-lts-announce/2021/06/msg00026.html"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://lists.debian.org/debian-lts-announce/2021/07/msg00012.html"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/AH46QHE5GIMT6BL6C3GDTOYF27JYILXM/"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EWFVYTHGILOQXUA7U3SPOERQXL7OPSZG/"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://www.oracle.com/security-alerts/cpuapr2022.html"
+                              },
+                              {
+                                "type": "WEB",
+                                "url": "https://www.oracle.com/security-alerts/cpujul2022.html"
+                              }
+                            ],
+                            "schema_version": "1.4.0",
+                            "severity": [
+                              {
+                                "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                                "type": "CVSS_V3"
+                              }
+                            ],
+                            "summary": "XML External Entity (XXE) Injection in JDOM"
+                          }
+                        ]
+                      },
+                      "severity": "error",
+                      "reason": "The input does not satisfy the function",
+                      "rationale": [
+                        {
+                          "name": {
+                            "pattern": "openvex::from-osv"
+                          },
+                          "bindings": {
+                            "terms": []
+                          },
+                          "input": {
+                            "vulns": [
+                              {
+                                "affected": [
+                                  {
+                                    "database_specific": {
+                                      "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2021/07/GHSA-2363-cqg2-863c/GHSA-2363-cqg2-863c.json"
+                                    },
+                                    "package": {
+                                      "ecosystem": "Maven",
+                                      "name": "org.jdom:jdom",
+                                      "purl": "pkg:maven/org.jdom/jdom"
+                                    },
+                                    "ranges": [
+                                      {
+                                        "events": [
+                                          {
+                                            "introduced": "0"
+                                          },
+                                          {}
+                                        ],
+                                        "type": "ECOSYSTEM"
+                                      }
+                                    ],
+                                    "versions": [
+                                      "1.1",
+                                      "1.1.2",
+                                      "1.1.3",
+                                      "2.0.0",
+                                      "2.0.1",
+                                      "2.0.2"
+                                    ]
+                                  }
+                                ],
+                                "aliases": [
+                                  "CVE-2021-33813"
+                                ],
+                                "database_specific": {
+                                  "cwe_ids": [
+                                    "CWE-611"
+                                  ],
+                                  "github_reviewed": true,
+                                  "github_reviewed_at": "2021-07-27T19:02:41Z",
+                                  "nvd_published_at": "2021-06-16T12:15:00Z",
+                                  "severity": "HIGH"
+                                },
+                                "details": "An XXE issue in SAXBuilder in JDOM through 2.0.6 allows attackers to cause a denial of service via a crafted HTTP request.  At this time there is not released fixed version of JDOM.  As a workaround, to avoid external entities being expanded, one can call `builder.setExpandEntities(false)` and they won't be expanded.",
+                                "id": "GHSA-2363-cqg2-863c",
+                                "modified": "2023-03-28T05:39:14.823719Z",
+                                "published": "2021-07-27T19:02:56Z",
+                                "references": [
+                                  {
+                                    "type": "ADVISORY",
+                                    "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-33813"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://github.com/hunterhacker/jdom/pull/188"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://github.com/hunterhacker/jdom/commit/dd4f3c2fc7893edd914954c73eb577f925a7d361"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://alephsecurity.com/vulns/aleph-2021003"
+                                  },
+                                  {
+                                    "type": "PACKAGE",
+                                    "url": "https://github.com/hunterhacker/jdom"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://github.com/hunterhacker/jdom/releases"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://lists.apache.org/thread.html/r21c406c7ed88fe340db7dbae75e58355159e6c324037c7d5547bf40b@%3Cissues.solr.apache.org%3E"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://lists.apache.org/thread.html/r5674106135bb1a6ef57483f4c63a9c44bca85d0e2a8a05895a8f1d89@%3Cissues.solr.apache.org%3E"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://lists.apache.org/thread.html/r6db397ae7281ead825338200d1f62d2827585a70797cc9ac0c4bd23f@%3Cissues.solr.apache.org%3E"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://lists.apache.org/thread.html/r845e987b7cd8efe610284958e997b84583f5a98d3394adc09e3482fe@%3Cissues.solr.apache.org%3E"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://lists.apache.org/thread.html/r89b3800cfabb1e773e49425e5d4239c28a659839a2eca6af3431482e@%3Cissues.solr.apache.org%3E"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://lists.apache.org/thread.html/r9974f64723875052e02787b2a5eda689ac5247c71b827d455e5dc9a6@%3Cissues.solr.apache.org%3E"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://lists.apache.org/thread.html/rbc075a4ac85e7a8e47420b7383f16ffa0af3b792b8423584735f369f@%3Cissues.solr.apache.org%3E"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://lists.apache.org/thread.html/rfb7a93e40ebeb1e0068cde0bf3834dcab46bb1ef06d6424db48ed9fd@%3Cdev.tika.apache.org%3E"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://lists.debian.org/debian-lts-announce/2021/06/msg00026.html"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://lists.debian.org/debian-lts-announce/2021/07/msg00012.html"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/AH46QHE5GIMT6BL6C3GDTOYF27JYILXM/"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EWFVYTHGILOQXUA7U3SPOERQXL7OPSZG/"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://www.oracle.com/security-alerts/cpuapr2022.html"
+                                  },
+                                  {
+                                    "type": "WEB",
+                                    "url": "https://www.oracle.com/security-alerts/cpujul2022.html"
+                                  }
+                                ],
+                                "schema_version": "1.4.0",
+                                "severity": [
+                                  {
+                                    "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                                    "type": "CVSS_V3"
+                                  }
+                                ],
+                                "summary": "XML External Entity (XXE) Injection in JDOM"
+                              }
+                            ]
+                          },
+                          "output": {
+                            "@context": "https://openvex.dev/ns",
+                            "@id": "https://seedwing.io/ROOT/generated/0ad182ef-13ba-4e9f-988a-ca46e194c9b6",
+                            "author": "Seedwing Policy Engine",
+                            "role": "Document Creator",
+                            "statements": [
+                              {
+                                "action_statement": "Review GHSA-2363-cqg2-863c for details on the appropriate action",
+                                "action_statement_timestamp": "2023-03-31T13:38:32.159612889Z",
+                                "products": [
+                                  "pkg:maven/org.jdom/jdom@1.1.2",
+                                  "pkg:maven/org.jdom/jdom@1.1",
+                                  "pkg:maven/org.jdom/jdom@1.1.3",
+                                  "pkg:maven/org.jdom/jdom@2.0.0",
+                                  "pkg:maven/org.jdom/jdom@2.0.1",
+                                  "pkg:maven/org.jdom/jdom@2.0.2"
+                                ],
+                                "status": "affected",
+                                "status_notes": "Open Source Vulnerabilities (OSV) found vulnerabilities",
+                                "timestamp": "2023-03-28T05:39:14.823719Z",
+                                "vuln_description": "XML External Entity (XXE) Injection in JDOM",
+                                "vulnerability": "GHSA-2363-cqg2-863c"
+                              }
+                            ],
+                            "supplier": "seedwing.io",
+                            "timestamp": "2023-03-31T13:38:32.159582368Z",
+                            "tooling": "Seedwing Policy Engine",
+                            "version": "1"
+                          },
+                          "severity": "none",
+                          "reason": "The input satisfies the function"
+                        },
+                        {
+                          "name": {
+                            "pattern": "lang::refine"
+                          },
+                          "bindings": {
+                            "terms": [],
+                            "refinement": {
+                              "statements": [
+                                {
+                                  "status": [
+                                    [
+                                      "affected",
+                                      "under_investigation"
+                                    ]
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "input": {
+                            "@context": "https://openvex.dev/ns",
+                            "@id": "https://seedwing.io/ROOT/generated/0ad182ef-13ba-4e9f-988a-ca46e194c9b6",
+                            "author": "Seedwing Policy Engine",
+                            "role": "Document Creator",
+                            "statements": [
+                              {
+                                "action_statement": "Review GHSA-2363-cqg2-863c for details on the appropriate action",
+                                "action_statement_timestamp": "2023-03-31T13:38:32.159612889Z",
+                                "products": [
+                                  "pkg:maven/org.jdom/jdom@1.1.2",
+                                  "pkg:maven/org.jdom/jdom@1.1",
+                                  "pkg:maven/org.jdom/jdom@1.1.3",
+                                  "pkg:maven/org.jdom/jdom@2.0.0",
+                                  "pkg:maven/org.jdom/jdom@2.0.1",
+                                  "pkg:maven/org.jdom/jdom@2.0.2"
+                                ],
+                                "status": "affected",
+                                "status_notes": "Open Source Vulnerabilities (OSV) found vulnerabilities",
+                                "timestamp": "2023-03-28T05:39:14.823719Z",
+                                "vuln_description": "XML External Entity (XXE) Injection in JDOM",
+                                "vulnerability": "GHSA-2363-cqg2-863c"
+                              }
+                            ],
+                            "supplier": "seedwing.io",
+                            "timestamp": "2023-03-31T13:38:32.159582368Z",
+                            "tooling": "Seedwing Policy Engine",
+                            "version": "1"
+                          },
+                          "severity": "error",
+                          "reason": "The input does not satisfy the function",
+                          "rationale": [
+                            {
+                              "name": {
+                                "pattern": "openvex::not-affected"
+                              },
+                              "input": {
+                                "@context": "https://openvex.dev/ns",
+                                "@id": "https://seedwing.io/ROOT/generated/0ad182ef-13ba-4e9f-988a-ca46e194c9b6",
+                                "author": "Seedwing Policy Engine",
+                                "role": "Document Creator",
+                                "statements": [
+                                  {
+                                    "action_statement": "Review GHSA-2363-cqg2-863c for details on the appropriate action",
+                                    "action_statement_timestamp": "2023-03-31T13:38:32.159612889Z",
+                                    "products": [
+                                      "pkg:maven/org.jdom/jdom@1.1.2",
+                                      "pkg:maven/org.jdom/jdom@1.1",
+                                      "pkg:maven/org.jdom/jdom@1.1.3",
+                                      "pkg:maven/org.jdom/jdom@2.0.0",
+                                      "pkg:maven/org.jdom/jdom@2.0.1",
+                                      "pkg:maven/org.jdom/jdom@2.0.2"
+                                    ],
+                                    "status": "affected",
+                                    "status_notes": "Open Source Vulnerabilities (OSV) found vulnerabilities",
+                                    "timestamp": "2023-03-28T05:39:14.823719Z",
+                                    "vuln_description": "XML External Entity (XXE) Injection in JDOM",
+                                    "vulnerability": "GHSA-2363-cqg2-863c"
+                                  }
+                                ],
+                                "supplier": "seedwing.io",
+                                "timestamp": "2023-03-31T13:38:32.159582368Z",
+                                "tooling": "Seedwing Policy Engine",
+                                "version": "1"
+                              },
+                              "severity": "error",
+                              "reason": "Because not all fields were satisfied",
+                              "rationale": [
+                                {
+                                  "name": {
+                                    "pattern": "list::none"
+                                  },
+                                  "bindings": {
+                                    "pattern": {
+                                      "status": [
+                                        [
+                                          "affected",
+                                          "under_investigation"
+                                        ]
+                                      ]
+                                    },
+                                    "refinement": {
+                                      "statements": [
+                                        {
+                                          "status": [
+                                            [
+                                              "affected",
+                                              "under_investigation"
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "terms": []
+                                  },
+                                  "input": [
+                                    {
+                                      "action_statement": "Review GHSA-2363-cqg2-863c for details on the appropriate action",
+                                      "action_statement_timestamp": "2023-03-31T13:38:32.159612889Z",
+                                      "products": [
+                                        "pkg:maven/org.jdom/jdom@1.1.2",
+                                        "pkg:maven/org.jdom/jdom@1.1",
+                                        "pkg:maven/org.jdom/jdom@1.1.3",
+                                        "pkg:maven/org.jdom/jdom@2.0.0",
+                                        "pkg:maven/org.jdom/jdom@2.0.1",
+                                        "pkg:maven/org.jdom/jdom@2.0.2"
+                                      ],
+                                      "status": "affected",
+                                      "status_notes": "Open Source Vulnerabilities (OSV) found vulnerabilities",
+                                      "timestamp": "2023-03-28T05:39:14.823719Z",
+                                      "vuln_description": "XML External Entity (XXE) Injection in JDOM",
+                                      "vulnerability": "GHSA-2363-cqg2-863c"
+                                    }
+                                  ],
+                                  "severity": "error",
+                                  "reason": "The input does not satisfy the function",
+                                  "rationale": [
+                                    {
+                                      "input": {
+                                        "action_statement": "Review GHSA-2363-cqg2-863c for details on the appropriate action",
+                                        "action_statement_timestamp": "2023-03-31T13:38:32.159612889Z",
+                                        "products": [
+                                          "pkg:maven/org.jdom/jdom@1.1.2",
+                                          "pkg:maven/org.jdom/jdom@1.1",
+                                          "pkg:maven/org.jdom/jdom@1.1.3",
+                                          "pkg:maven/org.jdom/jdom@2.0.0",
+                                          "pkg:maven/org.jdom/jdom@2.0.1",
+                                          "pkg:maven/org.jdom/jdom@2.0.2"
+                                        ],
+                                        "status": "affected",
+                                        "status_notes": "Open Source Vulnerabilities (OSV) found vulnerabilities",
+                                        "timestamp": "2023-03-28T05:39:14.823719Z",
+                                        "vuln_description": "XML External Entity (XXE) Injection in JDOM",
+                                        "vulnerability": "GHSA-2363-cqg2-863c"
+                                      },
+                                      "output": {
+                                        "action_statement": "Review GHSA-2363-cqg2-863c for details on the appropriate action",
+                                        "action_statement_timestamp": "2023-03-31T13:38:32.159612889Z",
+                                        "products": [
+                                          "pkg:maven/org.jdom/jdom@1.1.2",
+                                          "pkg:maven/org.jdom/jdom@1.1",
+                                          "pkg:maven/org.jdom/jdom@1.1.3",
+                                          "pkg:maven/org.jdom/jdom@2.0.0",
+                                          "pkg:maven/org.jdom/jdom@2.0.1",
+                                          "pkg:maven/org.jdom/jdom@2.0.2"
+                                        ],
+                                        "status": "affected",
+                                        "status_notes": "Open Source Vulnerabilities (OSV) found vulnerabilities",
+                                        "timestamp": "2023-03-28T05:39:14.823719Z",
+                                        "vuln_description": "XML External Entity (XXE) Injection in JDOM",
+                                        "vulnerability": "GHSA-2363-cqg2-863c"
+                                      },
+                                      "severity": "none",
+                                      "reason": "Because all fields were satisfied",
+                                      "rationale": [
+                                        {
+                                          "name": {
+                                            "pattern": "lang::or"
+                                          },
+                                          "bindings": {
+                                            "terms": [
+                                              "affected",
+                                              "under_investigation"
+                                            ]
+                                          },
+                                          "input": "affected",
+                                          "output": "affected",
+                                          "severity": "none",
+                                          "reason": "The input satisfies the function",
+                                          "rationale": [
+                                            {
+                                              "input": "affected",
+                                              "output": "affected",
+                                              "severity": "none",
+                                              "reason": "The input matches the expected constant value expected in the pattern"
+                                            },
+                                            {
+                                              "input": "affected",
+                                              "severity": "error",
+                                              "reason": "The input does not match the constant value expected in the pattern"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/engine/tests/response.rs
+++ b/engine/tests/response.rs
@@ -1,0 +1,85 @@
+use seedwing_policy_engine::lang::Severity;
+use seedwing_policy_engine::runtime::Response;
+use serde_json::json;
+
+#[test]
+fn test_collapse() {
+    let response: Response =
+        serde_json::from_str(include_str!("response-data/proxy-jdom.json")).unwrap();
+
+    // should be error
+    assert_eq!(response.severity, Severity::Error);
+
+    let response = response.collapse(Severity::Error);
+
+    // should still be error after collapsing
+    assert_eq!(response.severity, Severity::Error);
+    assert_eq!(
+        serde_json::to_value(&response).unwrap(),
+        json!({
+            "name":{
+                "pattern":"test::not-affected"
+            },
+            "input":{
+                "hash":"02bd61a725e8af9b0176b43bf29816d0c748b8ab951385bd127be37489325a0a",
+                "purl":"pkg:maven/org.jdom/jdom@1.1.3?type=jar&repository_url=https%3A%2F%2Frepo.maven.apache.org%2Fmaven2",
+                "url":"https://repo.maven.apache.org/maven2/org/jdom/jdom/1.1.3/jdom-1.1.3.jar"
+            },
+            "severity":"error",
+            "reason":"Because not all fields were satisfied",
+            "rationale":[
+                {
+                    "name":{
+                        "pattern":"list::none"
+                    },
+                    "bindings":{
+                        "pattern":{
+                            "status":[
+                                [
+                                    "affected",
+                                    "under_investigation"
+                                ]
+                            ]
+                        },
+                        "refinement":{
+                            "statements":[
+                                {
+                                    "status":[
+                                        [
+                                            "affected",
+                                            "under_investigation"
+                                        ]
+                                    ]
+                                }
+                            ]
+                        },
+                        "terms":[
+
+                        ]
+                    },
+                    "input":[
+                        {
+                            "action_statement":"Review GHSA-2363-cqg2-863c for details on the appropriate action",
+                            "action_statement_timestamp": "2023-03-31T13:38:32.159612889Z",
+                            "products":[
+                                "pkg:maven/org.jdom/jdom@1.1.2",
+                                "pkg:maven/org.jdom/jdom@1.1",
+                                "pkg:maven/org.jdom/jdom@1.1.3",
+                                "pkg:maven/org.jdom/jdom@2.0.0",
+                                "pkg:maven/org.jdom/jdom@2.0.1",
+                                "pkg:maven/org.jdom/jdom@2.0.2"
+                            ],
+                            "status":"affected",
+                            "status_notes":"Open Source Vulnerabilities (OSV) found vulnerabilities",
+                            "timestamp": "2023-03-28T05:39:14.823719Z",
+                            "vuln_description":"XML External Entity (XXE) Injection in JDOM",
+                            "vulnerability":"GHSA-2363-cqg2-863c"
+                        }
+                    ],
+                    "severity":"error",
+                    "reason":"The input does not satisfy the function"
+                }
+            ]
+        })
+    );
+}

--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -1531,8 +1531,7 @@ checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 [[package]]
 name = "patternfly-yew"
 version = "0.4.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66546818b7b756aa0643b40d906ab4cc261443aa714254e2f7051c9f3904148e"
+source = "git+https://github.com/ctron/patternfly-yew?rev=9e9479d00e28dbbf072eca8717503c42e8859822#9e9479d00e28dbbf072eca8717503c42e8859822"
 dependencies = [
  "chrono",
  "gloo-events",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -42,7 +42,7 @@ opt-level = 's'
 lto = true
 
 [patch.crates-io]
-#patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "90ddfd7ae07aea2457528449bcaa088b17d245f8" }
+patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "9e9479d00e28dbbf072eca8717503c42e8859822" }
 monaco = { git = "https://github.com/siku2/rust-monaco", rev = "794a4cc7819f9ed7eb06559e24f75a41e23cf22a" }
 #patternfly-yew = { path = "../../patternfly-yew" }
 #yew-nested-router = { path = "../../yew-nested-router" }

--- a/frontend/src/common/eval.rs
+++ b/frontend/src/common/eval.rs
@@ -1,4 +1,5 @@
 use patternfly_yew::prelude::*;
+use seedwing_policy_engine::lang::Severity;
 use seedwing_policy_engine::runtime::response::{Name, Response};
 use serde_json::Value;
 use std::rc::Rc;
@@ -34,16 +35,16 @@ impl TreeNode for ResponseModel {
     fn render_cell(&self, ctx: CellContext) -> Cell {
         match ctx.column {
             0 => {
-                let state = match self.0.satisfied {
-                    true => HelperTextState::Success,
-                    false => HelperTextState::Error,
+                let (icon,state) = match self.0.severity {
+                    Severity::None => (None, HelperTextState::Success),
+                    Severity::Advice=> (Some(Icon::InfoCircle), HelperTextState::Default),
+                    Severity::Warning => (None, HelperTextState::Warning),
+                    Severity::Error => (None, HelperTextState::Error),
                 };
                 html!(
-                    <>
-                        <HelperText>
-                            <HelperTextItem {state}>{ &self.0.reason }</HelperTextItem>
-                        </HelperText>
-                    </>
+                    <HelperText>
+                        <HelperTextItem {state} {icon}>{ &self.0.reason }</HelperTextItem>
+                    </HelperText>
                 )
             }
             1 => {

--- a/frontend/src/pages/inspector/mod.rs
+++ b/frontend/src/pages/inspector/mod.rs
@@ -65,7 +65,7 @@ pub fn inspector() -> Html {
 
     html!(
         <>
-            <PageSection variant={PageSectionVariant::Light} sticky={[PageSectionSticky::Top]}>
+            <PageSection variant={PageSectionVariant::Light}>
                 <Content>
                     <Title size={Size::XXXXLarge}>{ "Inspector" }</Title>
                     <p>

--- a/frontend/src/pages/inspector/mod.rs
+++ b/frontend/src/pages/inspector/mod.rs
@@ -9,7 +9,6 @@ const INITIAL_VALUE: &str = r#"{
       "pattern": "inspector"
     },
     "input": "If you paste the JSON output of an evaluation into the editor, you can in drill into details on the 'Inspect' tab.",
-    "satisfied": true,
     "reason": "This is just an example"
 }"#;
 

--- a/server/src/api/format.rs
+++ b/server/src/api/format.rs
@@ -46,8 +46,8 @@ impl Format {
         }
         match self {
             Self::Html => Ok(Rationalizer::new(result).rationale()),
-            Self::Json => serde_json::to_string_pretty(&response).map_err(|e| FormatError::Json(e)),
-            Self::Yaml => serde_yaml::to_string(&response).map_err(|e| FormatError::Yaml(e)),
+            Self::Json => serde_json::to_string_pretty(&response).map_err(FormatError::Json),
+            Self::Yaml => serde_yaml::to_string(&response).map_err(FormatError::Yaml),
         }
     }
     pub fn content_type(&self) -> ContentType {

--- a/server/src/api/format.rs
+++ b/server/src/api/format.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Display};
 
 use crate::ui::rationale::Rationalizer;
 use actix_web::http::header::ContentType;
+use seedwing_policy_engine::lang::Severity;
 use seedwing_policy_engine::runtime::{EvaluationResult, Response};
 use serde::Deserialize;
 
@@ -37,7 +38,7 @@ impl Format {
         let mut response = if let Self::Html = self {
             Response::default()
         } else if collapse {
-            Response::new(result).collapse()
+            Response::new(result).collapse(Severity::Error)
         } else {
             Response::new(result)
         };
@@ -50,6 +51,7 @@ impl Format {
             Self::Yaml => serde_yaml::to_string(&response).map_err(FormatError::Yaml),
         }
     }
+
     pub fn content_type(&self) -> ContentType {
         match self {
             Self::Html => ContentType::html(),

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -33,12 +33,10 @@ pub async fn get_policy(world: web::Data<World>, path: web::Path<String>) -> imp
         } else {
             HttpResponse::NotFound().finish()
         }
+    } else if let Some(meta) = world.get_pattern_meta(path) {
+        HttpResponse::Ok().json(ComponentMetadata::Pattern(meta))
     } else {
-        if let Some(meta) = world.get_pattern_meta(path) {
-            HttpResponse::Ok().json(ComponentMetadata::Pattern(meta))
-        } else {
-            HttpResponse::NotFound().finish()
-        }
+        HttpResponse::NotFound().finish()
     }
 
     /*

--- a/server/src/ui/rationale.rs
+++ b/server/src/ui/rationale.rs
@@ -73,7 +73,6 @@ impl<'r> Rationalizer<'r> {
                         Self::rationale_inner(html, each);
                     }
                 }
-                Rationale::Refinement(_, _) => {}
             }
             html.push_str("</div>");
         } else if result.severity() < Severity::Error {
@@ -221,12 +220,6 @@ impl<'r> Rationalizer<'r> {
                     }
                 }
                  */
-            }
-            Rationale::Refinement(primary, refinement) => {
-                Self::rationale_inner(html, primary);
-                if let Some(refinement) = refinement {
-                    Self::rationale_inner(html, refinement);
-                }
             }
         }
     }

--- a/swio/src/command/bench.rs
+++ b/swio/src/command/bench.rs
@@ -84,6 +84,6 @@ impl Bench {
             .unwrap()
         );
 
-        return Ok(ExitCode::SUCCESS);
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/swio/src/command/eval.rs
+++ b/swio/src/command/eval.rs
@@ -1,6 +1,7 @@
 use crate::cli::{Context, InputType};
 use crate::util;
 use crate::util::load_values;
+use seedwing_policy_engine::lang::Severity;
 use seedwing_policy_engine::runtime::Response;
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -52,11 +53,11 @@ impl Eval {
                 let response = if self.verbose {
                     Response::new(&result)
                 } else {
-                    Response::new(&result).collapse()
+                    Response::new(&result).collapse(Severity::Error)
                 };
 
                 println!("{}", serde_json::to_string_pretty(&response).unwrap());
-                if !result.satisfied() {
+                if result.severity() >= Severity::Error {
                     return Ok(ExitCode::from(2));
                 }
             }

--- a/swio/src/command/eval.rs
+++ b/swio/src/command/eval.rs
@@ -46,7 +46,7 @@ impl Eval {
         let values = load_values(self.typ, inputs).await?;
         for value in values {
             for name in names.iter() {
-                let eval = util::eval::Eval::new(&world, &name, value.clone());
+                let eval = util::eval::Eval::new(&world, name, value.clone());
 
                 let result = eval.run().await?;
                 let response = if self.verbose {

--- a/swio/src/command/test.rs
+++ b/swio/src/command/test.rs
@@ -158,8 +158,6 @@ impl TestPlan {
                                                 Expected::Identity
                                             } else if parent.join("output.any").exists() {
                                                 Expected::Anything
-                                            } else if parent.join("output.none").exists() {
-                                                Expected::None
                                             } else {
                                                 Expected::Pending
                                             };
@@ -394,9 +392,6 @@ impl TestCase {
 
                     match result {
                         Ok(result) => match (result.raw_output(), &self.expected) {
-                            (Output::None, Expected::None) => {
-                                self.result.replace(TestResult::Passed);
-                            }
                             (Output::Identity, Expected::Identity) => {
                                 self.result.replace(TestResult::Passed);
                             }
@@ -457,7 +452,6 @@ pub enum Expected {
     Anything,
     Identity,
     Transform(PathBuf),
-    None,
 }
 
 #[derive(Debug)]

--- a/swio/src/util/eval.rs
+++ b/swio/src/util/eval.rs
@@ -19,11 +19,7 @@ impl<'a> Eval<'a> {
 
     pub async fn run(&self) -> Result<EvaluationResult, RuntimeError> {
         self.world
-            .evaluate(
-                self.name.clone(),
-                self.value.clone(),
-                EvalContext::default(),
-            )
+            .evaluate(self.name, self.value.clone(), EvalContext::default())
             .await
     }
 }


### PR DESCRIPTION
This adds the concept of severities (warning, advice, error).

It takes a different approach than explored in https://github.com/seedwing-io/rfcs/pull/1. It does not add a set of reasons for each severity/level, but only one.

The main changes in this PR are:

* Instead of having a `satisfied` state, we now have a `severity`. Where `Severity::Error` means `satisfied=false` and everything else `satisfied=true`.
* Instead of using the `Output::None` variant to report `satisfied=false`, this is now down by the "severity". Output is reduced to only carry the (value) output information, which is either "transformed" or "identity"
* By default functionality which returned `satisifed=false` now return `Severity::Error`. Functionality which required to check of `satisfied=true` now checks for `severity < Severity::Error` (as severities are ordered).

This PR isn't finished. There are some things to work on:

* [x] Fix all tests (a lot of them don't compile because of a change API). After adapting to the new API, things should work as before, as most of the logic should (is expected to be) still valid
* [x] Check all aggregating functions. Based on the idea of "satisfied", they should work the same. But I need to check the cases of "in the middle" (advice, warning). Add tests for those too.
* [ ] Possibly more