### PR TITLE
feat: add a semantic version parser. Fixes #158

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3485,6 +3485,7 @@ dependencies = [
  "regex",
  "reqwest",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/docs/modules/policies/nav.adoc
+++ b/docs/modules/policies/nav.adoc
@@ -23,6 +23,7 @@
 ** xref:osv/index.adoc[`osv`]
 ** xref:pem/index.adoc[`pem`]
 ** xref:rhsa/index.adoc[`rhsa`]
+** xref:semver/index.adoc[`semver`]
 ** xref:showcase/index.adoc[`showcase`]
 ** xref:sigstore/index.adoc[`sigstore`]
 ** xref:slsa/index.adoc[`slsa`]

--- a/docs/modules/policies/pages/semver/index.adoc
+++ b/docs/modules/policies/pages/semver/index.adoc
@@ -1,0 +1,22 @@
+= semver
+:sectanchors:
+
+
+
+[#parse]
+== `parse`
+
+Convert a semver string into a `semver` object.
+
+Example input:
+
+[source,json]
+----
+"0.5.3-beta9+20230401"
+----
+
+
+[#semver]
+== `semver`
+
+

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -47,6 +47,7 @@ openvex = "0.1.0"
 spdx = "0.10.0"
 csaf = {version = "0.4.0", default-features = false }
 guac-rs = { git = "https://github.com/dejanb/guac-rs.git", rev = "67a70e98ffaa17200d256e1afc5c88756b56d5e2" }
+semver = "1.0"
 
 
 # monitoring

--- a/engine/src/core/mod.rs
+++ b/engine/src/core/mod.rs
@@ -34,6 +34,7 @@ pub mod openvex;
 pub mod osv;
 pub mod pem;
 pub mod rhsa;
+pub mod semver;
 #[cfg(feature = "showcase")]
 pub mod showcase;
 #[cfg(feature = "sigstore")]

--- a/engine/src/core/semver/mod.rs
+++ b/engine/src/core/semver/mod.rs
@@ -1,0 +1,12 @@
+mod parse;
+
+use crate::core::semver::parse::SemverParse;
+use crate::package::Package;
+use crate::runtime::PackagePath;
+
+pub fn package() -> Package {
+    let mut pkg = Package::new(PackagePath::from_parts(vec!["semver"]));
+    pkg.register_source("".into(), include_str!("semver.dog"));
+    pkg.register_function("parse".into(), SemverParse);
+    pkg
+}

--- a/engine/src/core/semver/parse.adoc
+++ b/engine/src/core/semver/parse.adoc
@@ -1,0 +1,8 @@
+Convert a semver string into a `semver` object.
+
+Example input:
+
+[source,json]
+----
+"0.5.3-beta9+20230401"
+----

--- a/engine/src/core/semver/parse.rs
+++ b/engine/src/core/semver/parse.rs
@@ -1,0 +1,164 @@
+use crate::core::{Function, FunctionEvaluationResult, FunctionInput};
+use crate::lang::lir::Bindings;
+use crate::runtime::{EvalContext, Output, Pattern, RuntimeError, World};
+use crate::value::{Object, RuntimeValue};
+use std::future::Future;
+use std::pin::Pin;
+
+use semver::Version;
+
+use crate::lang::{PatternMeta, Severity};
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct SemverParse;
+const DOCUMENTATION: &str = include_str!("parse.adoc");
+
+impl Function for SemverParse {
+    fn input(&self, _bindings: &[Arc<Pattern>]) -> FunctionInput {
+        FunctionInput::String
+    }
+
+    fn metadata(&self) -> PatternMeta {
+        PatternMeta {
+            documentation: DOCUMENTATION.into(),
+            ..Default::default()
+        }
+    }
+
+    fn call<'v>(
+        &'v self,
+        input: Arc<RuntimeValue>,
+        _ctx: &'v EvalContext,
+        _bindings: &'v Bindings,
+        _world: &'v World,
+    ) -> Pin<Box<dyn Future<Output = Result<FunctionEvaluationResult, RuntimeError>> + 'v>> {
+        Box::pin(async move {
+            if let Some(value) = input.try_get_string() {
+                if let Ok(version) = Version::parse(value.as_str()) {
+                    let mut semantic_version = Object::new();
+                    semantic_version.set::<&str, u64>("major", version.major);
+                    semantic_version.set::<&str, u64>("minor", version.minor);
+                    semantic_version.set::<&str, u64>("patch", version.patch);
+                    if !version.pre.is_empty() {
+                        semantic_version.set::<&str, &str>("pre", version.pre.as_str());
+                    }
+                    if !version.build.is_empty() {
+                        semantic_version.set::<&str, &str>("build", version.build.as_str());
+                    }
+
+                    return Ok(Output::Transform(Arc::new(semantic_version.into())).into());
+                }
+            }
+            Ok(Severity::Error.into())
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::assert_satisfied;
+    use crate::runtime::testutil::test_common;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    pub async fn test_semver() {
+        let result = test_common(
+            r#"
+pattern test = semver::parse
+"#,
+            "0.1.2",
+        )
+        .await;
+
+        assert_satisfied!(&result);
+        assert_eq!(
+            result.output(),
+            Arc::new(
+                json!({
+                    "major": 0,
+                    "minor": 1,
+                    "patch": 2,
+                })
+                .into()
+            )
+        )
+    }
+
+    #[tokio::test]
+    pub async fn test_semver_with_beta() {
+        let result = test_common(
+            r#"
+pattern test = semver::parse
+"#,
+            "0.1.2-beta1",
+        )
+        .await;
+
+        assert_satisfied!(&result);
+        assert_eq!(
+            result.output(),
+            Arc::new(
+                json!({
+                    "major": 0,
+                    "minor": 1,
+                    "patch": 2,
+                    "pre": "beta1"
+                })
+                .into()
+            )
+        )
+    }
+
+    #[tokio::test]
+    pub async fn test_semver_with_build() {
+        let result = test_common(
+            r#"
+pattern test = semver::parse
+"#,
+            "0.1.2+01042023",
+        )
+        .await;
+
+        assert_satisfied!(&result);
+        assert_eq!(
+            result.output(),
+            Arc::new(
+                json!({
+                    "major": 0,
+                    "minor": 1,
+                    "patch": 2,
+                    "build": "01042023"
+                })
+                .into()
+            )
+        )
+    }
+
+    #[tokio::test]
+    pub async fn test_semver_with_pre_and_build() {
+        let result = test_common(
+            r#"
+pattern test = semver::parse
+"#,
+            "0.1.2-beta+01042023",
+        )
+        .await;
+
+        assert_satisfied!(&result);
+        assert_eq!(
+            result.output(),
+            Arc::new(
+                json!({
+                    "major": 0,
+                    "minor": 1,
+                    "patch": 2,
+                    "pre": "beta",
+                    "build": "01042023"
+                })
+                .into()
+            )
+        )
+    }
+}

--- a/engine/src/core/semver/semver.dog
+++ b/engine/src/core/semver/semver.dog
@@ -1,0 +1,11 @@
+
+// TODO restrict to the valid regexp for pre and build fields :
+// 0-9, A-Z, a-z, -
+
+pattern semver = {
+  major: integer,
+  minor: integer,
+  patch: integer,
+  pre?: string,
+  build?: string,
+}

--- a/engine/src/lang/hir/mod.rs
+++ b/engine/src/lang/hir/mod.rs
@@ -402,6 +402,7 @@ impl World {
         world.add_package(crate::core::maven::package());
         world.add_package(crate::core::external::package());
         world.add_package(crate::core::guac::package());
+        world.add_package(crate::core::semver::package());
 
         #[cfg(feature = "showcase")]
         world.add_package(crate::core::showcase::package());

--- a/engine/src/value/mod.rs
+++ b/engine/src/value/mod.rs
@@ -114,6 +114,12 @@ impl From<u32> for RuntimeValue {
     }
 }
 
+impl From<u64> for RuntimeValue {
+    fn from(inner: u64) -> Self {
+        Self::Integer(inner as _)
+    }
+}
+
 impl From<i16> for RuntimeValue {
     fn from(inner: i16) -> Self {
         Self::Integer(inner as _)


### PR DESCRIPTION
Question for the person that will review this : 

Should the `semver.dog` file define the regexp for pre and build as well ? 
(Note that the above regexps are [probably wrong](https://regex101.com/r/vkijKf/1/))
```
pattern alphanumeric-identifier = string::regexp<"[a-Za-z0-9]">
pattern pre-release = alphanumeric-identifier
pattern build = alphanumeric-identifier

pattern semver = {
  major: integer,
  minor: integer,
  patch: integer,
  pre?: pre-release,
  build?: build,
}
```