### PR TITLE
chore: replace danbev revision with sigstore org

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "sigstore"
 version = "0.6.0"
-source = "git+https://github.com/danbev/sigstore-rs.git?rev=0b3074bf44a5c2fb3b81f27d6ddf19cf4372e5f1#0b3074bf44a5c2fb3b81f27d6ddf19cf4372e5f1"
+source = "git+https://github.com/sigstore/sigstore-rs.git?rev=4d2629cd2b0e91c3437c1b29d2ea52b3233d52ff#4d2629cd2b0e91c3437c1b29d2ea52b3233d52ff"
 dependencies = [
  "async-trait",
  "base64 0.21.0",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -32,8 +32,7 @@ sha2 = "0.10.6"
 
 # functions
 #sigstore = { version = "0.6.0", optional = true }
-# FIXME waiting for https://github.com/sigstore/sigstore-rs/pull/239
-sigstore = { optional = true, git = "https://github.com/danbev/sigstore-rs.git", rev = "0b3074bf44a5c2fb3b81f27d6ddf19cf4372e5f1"  }
+sigstore = { optional = true, git = "https://github.com/sigstore/sigstore-rs.git", rev = "4d2629cd2b0e91c3437c1b29d2ea52b3233d52ff"  }
 x509-parser = "0.14.0"
 base64 = "0.21.0"
 regex = "1.7.1"


### PR DESCRIPTION
This commit removes danbev's revision and replaces it with the sigstore organisation and revision now that
https://github.com/sigstore/sigstore-rs/pull/239 has been merged.