### PR TITLE
docs: add example for lang::traverse

### DIFF
--- a/docs/modules/policies/pages/lang/index.adoc
+++ b/docs/modules/policies/pages/lang/index.adoc
@@ -46,6 +46,13 @@ pattern person = lang::traverse<"person">
 pattern name = person(lang::traverse<"name">)
 ```
 
+This can also be written as:
+```
+pattern person = lang::traverse<"person">
+
+pattern name = person(self.name)
+```
+
 Example input:
 ```
 {

--- a/docs/modules/policies/pages/lang/index.adoc
+++ b/docs/modules/policies/pages/lang/index.adoc
@@ -39,3 +39,24 @@ Pattern which applies the first parameter pattern, and if successful, applies th
 
 Pattern which produces the result of traversing to the named field of an input object.
 
+Example pattern:
+```
+pattern person = lang::traverse<"person">
+
+pattern name = person(lang::traverse<"name">)
+```
+
+Example input:
+```
+{
+  "type": "something",
+  "person": { 
+    "name": "Fletch",
+    "age": 48
+  },
+  "location": "some location"
+}
+```
+
+Evaluating the `name` pattern will in this case result in "Fletch".
+

--- a/engine/src/core/lang/traverse.adoc
+++ b/engine/src/core/lang/traverse.adoc
@@ -7,6 +7,13 @@ pattern person = lang::traverse<"person">
 pattern name = person(lang::traverse<"name">)
 ```
 
+This can also be written as:
+```
+pattern person = lang::traverse<"person">
+
+pattern name = person(self.name)
+```
+
 Example input:
 ```
 {

--- a/engine/src/core/lang/traverse.adoc
+++ b/engine/src/core/lang/traverse.adoc
@@ -1,1 +1,22 @@
 Pattern which produces the result of traversing to the named field of an input object.
+
+Example pattern:
+```
+pattern person = lang::traverse<"person">
+
+pattern name = person(lang::traverse<"name">)
+```
+
+Example input:
+```
+{
+  "type": "something",
+  "person": { 
+    "name": "Fletch",
+    "age": 48
+  },
+  "location": "some location"
+}
+```
+
+Evaluating the `name` pattern will in this case result in "Fletch".

--- a/engine/src/core/lang/traverse.rs
+++ b/engine/src/core/lang/traverse.rs
@@ -49,3 +49,23 @@ impl Function for Traverse {
         })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::value::RuntimeValue;
+    use crate::{assert_satisfied, runtime::testutil::test_pattern};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn traverse() {
+        let json = json!({
+            "person": { "name": "Fletch", "age": 48}
+        });
+        let result = test_pattern(r#"lang::traverse<"person">"#, json).await;
+        assert_satisfied!(&result);
+        assert!(result.output().is_object());
+        let person = result.output().as_json();
+        assert_eq!("Fletch", person.get("name").unwrap().as_str().unwrap());
+        assert_eq!(RuntimeValue::Integer(48), person.get("age").unwrap().into());
+    }
+}


### PR DESCRIPTION
This commit adds an example and a test for the `lang::traverse` function.

The motivation for this is that I think I should use it with the SPDX patterns but was not sure how it worked. Hopefully this will be useful for others in the same situation.