### PR TITLE
fix: add check for duplicate field names

### DIFF
--- a/engine/src/core/csaf/v2_0.dog
+++ b/engine/src/core/csaf/v2_0.dog
@@ -53,10 +53,9 @@ pattern note-category = "description" || "details" || "faq" || "general" || "leg
 
 pattern publisher = {
   category: publisher-category,
-  contact_details: uri::url,
   name: string,
   namespace: string,
-  //contact_details?: string,
+  contact_details?: string,
   issuing_authority?: string,
 }
 

--- a/engine/src/core/csaf/v2_0.dog
+++ b/engine/src/core/csaf/v2_0.dog
@@ -56,7 +56,7 @@ pattern publisher = {
   contact_details: uri::url,
   name: string,
   namespace: string,
-  contact_details?: string,
+  //contact_details?: string,
   issuing_authority?: string,
 }
 

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -161,7 +161,7 @@ pub async fn evaluate(
             log::error!("unable to build policy [{:?}]", e);
             let EvaluateRequest { value, name, .. } = body.0;
             HttpResponse::NotAcceptable().json(json!({
-                "name": { "pattern": format!("playground::{}", name)},
+                "name": { "pattern": format!("playground::{name}")},
                 "output": e.to_string(),
                 "input": value,
                 "reason": "Unable to build the policy",

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -159,7 +159,14 @@ pub async fn evaluate(
         },
         Err(e) => {
             log::error!("unable to build policy [{:?}]", e);
-            HttpResponse::NotAcceptable().body(e)
+            let EvaluateRequest { value, name, .. } = body.0;
+            HttpResponse::NotAcceptable().json(json!({
+                "name": { "pattern": format!("playground::{}", name)},
+                "output": e.to_string(),
+                "input": value,
+                "reason": "Unable to build the policy",
+                "severity": "error"
+            }))
         }
     }
 }


### PR DESCRIPTION
This commit adds a check to make sure that duplicate field names cause an error to be reported.

For example, with this commit starting the swio server will generate the following error:
```
$ cargo r --bin swio -- serve
     Running `target/debug/swio serve`
Error: 
    ╭─[csaf:59:3]
    │
 59 │   contact_details?: string,
    │   ────────────┬───────────  
    │               ╰───────────── Duplicate field declared. Please remove one of "contact_details"
────╯
```
Fixes: https://github.com/seedwing-io/seedwing-policy/issues/181