### PR TITLE
refactor: use an IndexMap to sort Response data fields

### DIFF
--- a/engine/src/core/external/remote.rs
+++ b/engine/src/core/external/remote.rs
@@ -47,14 +47,14 @@ impl Remote {
         // execute request
         let response = client.evaluate(url, input).await?;
 
-        let output = match response.output {
+        let output = match response.output() {
             Some(output) => Output::Transform(Arc::new(output.into())),
             None => Output::Identity,
         };
 
         // convert the response
         let response = FunctionEvaluationResult {
-            severity: response.severity,
+            severity: response.severity(),
             output,
             rationale: None,
             supporting: vec![],

--- a/engine/src/runtime/response/collector.rs
+++ b/engine/src/runtime/response/collector.rs
@@ -37,7 +37,7 @@ impl<'r> Collector<'r> {
     /// **NOTE:** This will only work properly of the severity of the response is higher than
     /// [`Severity::None`], otherwise you will get all leaf entries.
     pub fn highest_severity(mut self) -> Self {
-        self.severity = self.response.severity;
+        self.severity = self.response.severity();
         self
     }
 
@@ -62,16 +62,16 @@ impl<'r> Collector<'r> {
                 return false;
             }
 
-            if response.authoritative
+            if response.authoritative()
                 || response
-                    .rationale
+                    .rationale()
                     .iter()
                     .all(|r| r.satisfied(self.severity))
             {
                 // we are not satisfied, but all our children are, or we are authoritative
                 // -> record ourself as an outer most (failed) entry
                 let mut response = response.clone();
-                response.rationale = vec![];
+                response.set_rationale(vec![]);
                 rationale.push(response);
                 return false;
             }

--- a/engine/src/test.rs
+++ b/engine/src/test.rs
@@ -27,15 +27,15 @@ impl TryFrom<Value> for Reason {
 impl From<Response> for Reason {
     fn from(value: Response) -> Self {
         Self {
-            name: match value.name {
+            name: match value.name() {
                 Name::Field(field) => format!("field:{field}"),
                 Name::Pattern(Some(pattern)) => pattern.to_string(),
                 Name::Pattern(None) => String::new(),
             },
-            severity: value.severity,
-            reason: value.reason,
+            severity: value.severity(),
+            reason: value.reason(),
             rationale: value
-                .rationale
+                .rationale()
                 .into_iter()
                 .map(|s| s.into())
                 .collect::<Vec<_>>(),

--- a/engine/tests/response.rs
+++ b/engine/tests/response.rs
@@ -8,12 +8,12 @@ fn test_collapse() {
         serde_json::from_str(include_str!("response-data/proxy-jdom.json")).unwrap();
 
     // should be error
-    assert_eq!(response.severity, Severity::Error);
+    assert_eq!(response.severity(), Severity::Error);
 
     let response = response.collapse(Severity::Error);
 
     // should still be error after collapsing
-    assert_eq!(response.severity, Severity::Error);
+    assert_eq!(response.severity(), Severity::Error);
     assert_eq!(
         serde_json::to_value(&response).unwrap(),
         json!({

--- a/server/src/api/format.rs
+++ b/server/src/api/format.rs
@@ -35,7 +35,7 @@ impl Format {
         collapse: bool,
         fields: Option<String>,
     ) -> Result<String, FormatError> {
-        let mut response = if let Self::Html = self {
+        let response = if let Self::Html = self {
             // in case it's HTML, this value will be ignored later on
             Response::default()
         } else if collapse {
@@ -44,7 +44,7 @@ impl Format {
             Response::new(result)
         };
         if let Some(s) = fields {
-            response.filter(&s);
+            response.filter(&s).map_err(FormatError::Json)?;
         }
         match self {
             // FIXME: Rationalizer should use `response` too, currently it ignored the collapse flag

--- a/swio/src/command/eval.rs
+++ b/swio/src/command/eval.rs
@@ -57,12 +57,12 @@ impl Eval {
                 let eval = util::eval::Eval::new(&world, name, value.clone());
 
                 let result = eval.run().await?;
-                let mut response = if self.verbose {
+                let response = if self.verbose {
                     Response::new(&result)
                 } else {
                     Response::new(&result).collapse(Severity::Error)
-                };
-                response.filter(&self.select);
+                }
+                .filter(&self.select)?;
 
                 println!("{}", serde_json::to_string_pretty(&response).unwrap());
                 if result.severity() >= Severity::Error {


### PR DESCRIPTION
I'm not sure if this is better or not yet

This is an attempt to eliminate the custom serialize logic from Response while still allowing users to set the order of fields.

It was inspired as an alternative to #207 

Some of the tests are still failing, but I stopped short of debugging them until someone else thinks this is an appropriate direction. I'm not convinced. 