### PR TITLE
feat: update slsa to version 1.0

### DIFF
--- a/engine/src/core/slsa/provenance-v1_0.dog
+++ b/engine/src/core/slsa/provenance-v1_0.dog
@@ -57,7 +57,7 @@ pattern builder = {
   // URI indicating the transitive closure of the trusted builder. This is intended to be the sole determiner of the SLSA Build level.
   id: builder-id,
   // Version numbers of components of the builder.
-  version?: list::any<{component: string, version: string}>,
+  version?: {},
   // Dependencies used by the orchestrator that are not run within the workload and that do not affect the build, but might affect the
   // provenance generation or security guarantees.
   builderDependencies?: list::all<artifact-reference>,
@@ -97,5 +97,5 @@ pattern artifact-reference = {
   // Media type (aka MIME type) of this artifact was interpreted.
   mediaType?: string,
   // Annotations provide additional information or metadata about the resource or artifact.
-  annotations?: list::all<{key: string, value: anything}>,
+  annotations?: {},
 }

--- a/engine/src/core/slsa/provenance-v1_0.dog
+++ b/engine/src/core/slsa/provenance-v1_0.dog
@@ -2,9 +2,9 @@
 
 /// SLSA 1.0 build provenance statement.
 pattern provenance = {
-  _type: "https://in-toto.io/Statement/v0.1",
+  _type: "https://in-toto.io/Statement/v1",
   subject: anything,
-  predicateType: "https://slsa.dev/provenance/v1-rc1",
+  predicateType: "https://slsa.dev/provenance/v1",
   predicate: predicate,
 }
 
@@ -29,7 +29,7 @@ pattern build-definition = {
   // The parameters that are under the control of the entity represented by builder.id. The primary intention of this field is for debugging, incident
   // response, and vulnerability management. The values here MAY be necessary for reproducing the build. There is no need to verify these parameters
   // because the build system is already trusted, and in many cases it is not practical to do so.
-  systemParameters?: anything,
+  internalParameters?: anything,
 
   // Unordered collection of artifacts needed at build time. Completeness is best effort, at least through SLSA Build L3. For example, if the build
   // script fetches and executes “example.com/foo.sh”, which in turn fetches “example.com/bar.tar.gz”, then both “foo.sh” and “bar.tar.gz” SHOULD be
@@ -57,7 +57,7 @@ pattern builder = {
   // URI indicating the transitive closure of the trusted builder. This is intended to be the sole determiner of the SLSA Build level.
   id: builder-id,
   // Version numbers of components of the builder.
-  version?: string,
+  version?: list::any<{component: string, version: string}>,
   // Dependencies used by the orchestrator that are not run within the workload and that do not affect the build, but might affect the
   // provenance generation or security guarantees.
   builderDependencies?: list::all<artifact-reference>,
@@ -89,9 +89,13 @@ pattern artifact-reference = {
   // One or more cryptographic digests of the contents of this artifact.
   digest?: anything,
   // The name for this artifact local to the build.
-  localName?: string,
+  name?: string,
+  // The contents of the resource or artifact.
+  content?: base64::base64,
   // URI identifying the location that this artifact was downloaded from, if different and not derivable from uri.
   downloadLocation?: string,
   // Media type (aka MIME type) of this artifact was interpreted.
-  mediaType?: string
+  mediaType?: string,
+  // Annotations provide additional information or metadata about the resource or artifact.
+  annotations?: list::all<{key: string, value: anything}>,
 }

--- a/engine/test-data/slsa/example1.json
+++ b/engine/test-data/slsa/example1.json
@@ -1,7 +1,7 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "subject": [{"name": "a", "digest": {"sha256": "5678..."}}],
-  "predicateType": "https://slsa.dev/provenance/v1-rc1",
+  "predicateType": "https://slsa.dev/provenance/v1",
   "predicate": {
     "buildDefinition": {
       "buildType": "https://example.com/Makefile",
@@ -10,7 +10,7 @@
         "digest": {"sha256": "1234..."},
         "entryPoint": "src:foo"
       },
-      "systemParameters": {"CFLAGS": "-O3"}
+      "internalParameters": {"CFLAGS": "-O3"}
     },
     "runDetails": {
       "builder":  {


### PR DESCRIPTION
This commit updates the slsa v1.0-rc (candidate release) to v1.0.

provenance:
* `_type` has been updated.
* `predicateType` has been updated.

builder:
* `version` is defined as map (string->string) which is currently a string.

buildDefinition:
* `systemParameters` has been renamed to `internalParameters`

artifact-reference/ResourceDescriptor:
* `localName` was renamed to just `name`.
* `content` field was added.
* `annotations` field was added.