### PR TITLE
chore: comment out ci benchmarks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,5 +74,5 @@ jobs:
       - name: Test
         run: cargo test -- --nocapture
 
-      - name: Benchmark
-        run: cargo bench --no-run
+        # - name: Benchmark
+        # run: cargo bench --no-run


### PR DESCRIPTION
This commit comments out the execution of benchmarks in the ci.yaml which is currently causing some disk storage issues and hopefully this will workaround those issues.