### PR TITLE
Set release to true to Trunk.toml

### DIFF
--- a/frontend/Trunk.toml
+++ b/frontend/Trunk.toml
@@ -1,3 +1,6 @@
+[build]
+release = true
+
 [serve]
 port = 8010
 open = false

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,6 +13,8 @@
 
   <link data-trunk rel="copy-file" href="assets/codicon.ttf">
 
+  <link data-trunk rel="rust" data-wasm-opt="s" />
+
   <base data-trunk-public-url/>
 </head>
 


### PR DESCRIPTION
This commit suggests setting the trunk configuration option `release` to true (default is false) in Trunk.toml.

The motivation for this is that a release build will invoke [wasm-opt] which performs a number of [optimizations] to make wasm smaller and faster.

This could also be specified as a environment variable if setting this in the Trunk.toml configuration file is the best option:
```
TRUNK_BUILD_RELEASE=true
```

[wasm-opt]: https://crates.io/crates/wasm-opt
[optimizations]: https://github.com/WebAssembly/binaryen#binaryen-optimizations

----
Example build output:
```console
$ trunk build
2023-04-24T10:18:11.500456Z  INFO 📦 starting build
2023-04-24T10:18:11.500821Z  INFO spawning asset pipelines
2023-04-24T10:18:11.738543Z  INFO copying directory path="assets/images"
2023-04-24T10:18:11.738575Z  INFO copying directory path="node_modules/@fortawesome/fontawesome-free/webfonts"
2023-04-24T10:18:11.738582Z  INFO copying directory path="node_modules/@patternfly/patternfly/assets"
2023-04-24T10:18:11.738625Z  INFO copying file path="assets/codicon.ttf"
2023-04-24T10:18:11.738680Z  INFO building seedwing-policy-frontend
2023-04-24T10:18:11.739332Z  INFO finished copying file path="assets/codicon.ttf"
2023-04-24T10:18:11.739377Z  INFO finished copying directory path="assets/images"
2023-04-24T10:18:11.739838Z  INFO finished copying directory path="node_modules/@fortawesome/fontawesome-free/webfonts"
2023-04-24T10:18:11.751021Z  INFO finished copying directory path="node_modules/@patternfly/patternfly/assets"
    Finished release [optimized] target(s) in 0.16s
2023-04-24T10:18:11.950111Z  INFO using system installed binary app=sass version=1.58.3 compiled with dart2js 2.19.2
2023-04-24T10:18:11.950133Z  INFO compiling sass/scss path="assets/style.scss"
2023-04-24T10:18:11.951594Z  INFO fetching cargo artifacts
2023-04-24T10:18:12.160986Z  INFO processing WASM for seedwing-policy-frontend
2023-04-24T10:18:12.178165Z  INFO calling wasm-bindgen for seedwing-policy-frontend
2023-04-24T10:18:12.584984Z  INFO copying generated wasm-bindgen artifacts
2023-04-24T10:18:12.586808Z  INFO calling wasm-opt
2023-04-24T10:18:15.420633Z  INFO finished compiling sass/scss path="assets/style.scss"
2023-04-24T10:18:33.833433Z  INFO copying generated wasm-opt artifacts
2023-04-24T10:18:33.836786Z  INFO applying new distribution
2023-04-24T10:18:33.842205Z  INFO ✅ success

```