### PR TITLE
fix: chumsky osx issue and serde-view regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23170228b96236b5a7299057ac284a321457700bc8c41a4476052f0f4ba5349d"
 dependencies = [
  "hashbrown 0.12.3",
- "stacker",
 ]
 
 [[package]]
@@ -3250,15 +3249,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
-name = "psm"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4232,19 +4222,6 @@ dependencies = [
  "signature 1.6.4",
  "ssh-encoding",
  "zeroize",
-]
-
-[[package]]
-name = "stacker"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "winapi",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 base64-serde = "0.7.0"
-chumsky = "0.9.2"
+chumsky = { version = "0.9.2", default-features = false, features = ["std"] }
 ariadne = "0.2.0"
 walkdir = "2.3.2"
 serde = { version = "1.0.152", features = ["rc", "derive"] }

--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -232,7 +232,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23170228b96236b5a7299057ac284a321457700bc8c41a4476052f0f4ba5349d"
 dependencies = [
  "hashbrown",
- "stacker",
 ]
 
 [[package]]
@@ -1658,15 +1657,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,19 +2154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2971cb691ca629f46174f73b1f95356c5617f89b4167f04107167c3dccb8dd89"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "stacker"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "winapi",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR fixes two things:

* Issue with chumsky compilation on osx
* Regression with serde_view upgrade. I created a quick workaround for this, but the proper fix would be to make `with_fields()` method to work properly with empty values