### PR TITLE
fix: update verify-envelope output names

### DIFF
--- a/docs/modules/policies/pages/intoto/index.adoc
+++ b/docs/modules/policies/pages/intoto/index.adoc
@@ -49,10 +49,10 @@ The type of the predicate.
 === `predicate`
 The predicate itself.
 
-=== `attesters_names`
+=== `attester_names`
 The attesters names that verified the signature.
 
-=== `artifact_names`
+=== `matched_subjects`
 The artifact names that were verified.
 
 This data can then be passed onto other pattens for further evaluating rules
@@ -94,7 +94,7 @@ Example output:
 [source,json]
 ----
 {
-  "attesters_names": [
+  "attester_names": [
     "dan"
   ],
   "predicate": {

--- a/engine/src/core/intoto/verify-envelope.adoc
+++ b/engine/src/core/intoto/verify-envelope.adoc
@@ -35,10 +35,10 @@ The type of the predicate.
 === `predicate`
 The predicate itself.
 
-=== `attesters_names`
+=== `attester_names`
 The attesters names that verified the signature.
 
-=== `artifact_names`
+=== `matched_subjects`
 The artifact names that were verified.
 
 This data can then be passed onto other pattens for further evaluating rules
@@ -80,7 +80,7 @@ Example output:
 [source,json]
 ----
 {
-  "attesters_names": [
+  "attester_names": [
     "dan"
   ],
   "predicate": {


### PR DESCRIPTION
This commit updates the output names for intoto::verify_envelope to match the names specified in the in-toto validation model.

Refs: https://github.com/in-toto/attestation/blob/main/docs/validation.md